### PR TITLE
Add split by expression, breaks existing flows

### DIFF
--- a/src/components/Flow.tsx
+++ b/src/components/Flow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ActionProps } from './Action';
-import { FlowDefinition, Action, Node, Position, SendMessage } from '../FlowDefinition';
+import { FlowDefinition, Action, Node, Position, SendMessage, UINode } from '../FlowDefinition';
 import { ContactFieldResult, SearchResult } from './ComponentMap';
 import { NodeComp, NodeProps } from './Node';
 import { NodeModal, NodeModalProps, EditableProps } from './NodeModal';
@@ -172,10 +172,11 @@ export class Flow extends React.PureComponent<FlowProps, FlowState> {
         this.resetState();
     }
 
-    private onUpdateRouter(props: Node) {
-        this.props.mutator.updateRouter(props,
+    private onUpdateRouter(props: Node, type: string) {
+        this.props.mutator.updateRouter(props, type,
             this.state.modalProps.draggedFrom,
             this.state.modalProps.newPosition);
+
         this.resetState();
     }
 
@@ -354,21 +355,28 @@ export class Flow extends React.PureComponent<FlowProps, FlowState> {
         var nodes: JSX.Element[] = [];
         for (let node of this.props.definition.nodes) {
             var uiNode = this.props.definition._ui.nodes[node.uuid];
-            nodes.push(<NodeComp key={node.uuid} node={node} position={uiNode.position} context={this.state.context} />)
+            nodes.push(<NodeComp key={node.uuid} node={node} ui={uiNode} context={this.state.context} />)
         }
 
         var dragNode = null;
         if (this.state.ghost) {
             let ghost = this.state.ghost
-            dragNode = <NodeComp
 
+            // start off screen
+            var ui: UINode = {
+                position: { x: -1000, y: -1000 }
+            }
+
+            if (ghost.router) {
+                ui.type = "wait_for_response"
+            }
+
+            dragNode = <NodeComp
                 key={ghost.uuid}
                 ref={(ele) => { this.ghostComp = ele }}
                 node={ghost}
                 context={this.state.context}
-
-                // start off screen
-                position={{ x: -1000, y: -1000 }}
+                ui={ui}
                 ghost={true}
 
             />

--- a/src/components/FlowMutator.tsx
+++ b/src/components/FlowMutator.tsx
@@ -136,7 +136,7 @@ export class FlowMutator {
         return props;
     }
 
-    public updateRouter(props: Node,
+    public updateRouter(props: Node, type: string,
         draggedFrom: DragPoint = null,
         newPosition: Position = null): Node {
 
@@ -160,6 +160,10 @@ export class FlowMutator {
             });
             node = this.definition.nodes[nodeDetails.nodeIdx];
         }
+
+        // update our type
+        var uiNode = this.definition._ui.nodes[props.uuid];
+        this.updateNodeUI(props.uuid, { $merge: { type: type } })
 
         this.components.initializeUUIDMap(this.definition);
         this.markDirty();

--- a/src/components/NodeModal.tsx
+++ b/src/components/NodeModal.tsx
@@ -7,7 +7,7 @@ import { FlowMutator } from './FlowMutator';
 import { DragPoint } from './Node';
 import { FlowContext } from './Flow';
 import { NodeForm } from './NodeForm';
-import { Position, Exit } from '../FlowDefinition';
+import { Node, Position, Exit, UINode } from '../FlowDefinition';
 
 var Select = require('react-select');
 var styles = require('./NodeModal.scss');
@@ -32,7 +32,7 @@ export interface NodeModalProps {
     editableProps?: EditableProps;
     changeType?: boolean;
     onUpdateAction: Function;
-    onUpdateRouter: Function;
+    onUpdateRouter(node: Node, type: string): void;
 
     newPosition?: Position;
     mutator?: FlowMutator;

--- a/src/components/actions/SaveToContact.tsx
+++ b/src/components/actions/SaveToContact.tsx
@@ -63,7 +63,8 @@ export class SaveToContactForm extends ActionForm<SaveToContact, {}> {
     renderForm(): JSX.Element {
         var initial: SearchResult = null;
         var action = this.getAction();
-        if (action && this.props.type == "save_to_contact") {
+
+        if (action && action.type == "save_to_contact") {
             initial = {
                 id: action.field,
                 name: action.name,

--- a/src/components/form/FormElement.scss
+++ b/src/components/form/FormElement.scss
@@ -24,7 +24,7 @@
     padding-top: 5px;
 }
 
-.help-text {
+.help_text {
     color: #bbb;
     font-size: 11px;
     padding-top: 6px;

--- a/src/components/form/FormElement.tsx
+++ b/src/components/form/FormElement.tsx
@@ -18,7 +18,7 @@ export class FormElement extends React.PureComponent<FormElementProps, {}> {
 
         var errors: JSX.Element[] = [];
         if (this.props.errors) {
-            this.props.errors.map((error)=>{
+            this.props.errors.map((error) => {
                 errors.push(<div key={Math.random()} className={styles.error}>{error}</div>);
             });
         }
@@ -27,13 +27,13 @@ export class FormElement extends React.PureComponent<FormElementProps, {}> {
         if (errors.length > 0) {
             errorDisplay = (
                 <div className={styles.errors}>
-                  {errors}
+                    {errors}
                 </div>
             );
         }
 
         var name = this.props.showLabel && this.props.name ? <div>{this.props.name}</div> : "";
-        var helpText = this.props.helpText && !errorDisplay ? <div className={styles["help-text"]}>{this.props.helpText}</div> : "";
+        var helpText = this.props.helpText && !errorDisplay ? <div className={styles.help_text}>{this.props.helpText}</div> : "";
 
         var classes = [styles.group];
         if (this.props.className) {

--- a/src/components/shared.scss
+++ b/src/components/shared.scss
@@ -4,7 +4,7 @@
     background: #aaa;
 }
 
-.switch {
+.wait-for-response {
     background: #677c91;
 }
 

--- a/src/services/Config.tsx
+++ b/src/services/Config.tsx
@@ -59,31 +59,26 @@ export class Config {
         // {type: "flow", name: "Run another flow", description: "Run another flow", component: Missing},
 
         // routers
-        // { type: "expression", name: "Split by Expression", description: "Split by a custom expression", form: SwitchRouterForm },
-        { type: "switch", name: "Wait for Response", description: "Wait for them to respond", form: SwitchRouterForm },
+        { type: "expression", name: "Split by Expression", description: "Split by a custom expression", form: SwitchRouterForm },
+        { type: "wait_for_response", name: "Wait for Response", description: "Wait for them to respond", form: SwitchRouterForm },
         // {type: "random", name: "Random Split", description: "Split them up randomly", form: RandomRouterForm}
 
     ]
 
     public getTypeConfig(type: string): TypeConfig {
-        for (let config of this.typeConfigs) {
-            if (config.type == type) {
-                return config;
-            }
+        var config = this.typeConfigs.find((config: TypeConfig) => { return config.type == type });
+        if (!config) {
+            throw new Error("No type configuration found for " + type);
         }
-
-        console.error("No type configuration found for", type);
-        return null;
+        return config;
     }
 
     public getOperatorConfig(type: string): Operator {
-        for (let operator of this.operators) {
-            if (operator.type == type) {
-                return operator;
-            }
+        var operator = this.operators.find((operator: Operator) => { return operator.type == type });
+        if (!operator) {
+            throw new Error("No operator found for " + type);
         }
-        console.error("No operator found for", type);
-        return null;
+        return operator;
     }
 
     public operators: Operator[] = [

--- a/test/NodeComp.test.tsx
+++ b/test/NodeComp.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import * as Interfaces from '../src/interfaces';
 import { NodeComp, NodeState } from '../src/components/Node';
 import { FlowLoader, FlowLoaderProps } from '../src/components/FlowLoader';
 import { ShallowWrapper, shallow, mount, render } from 'enzyme';


### PR DESCRIPTION
Fixes: #22 - Can't click header on splits
Fixes: #12 - Split by expression

Be warned, all existing flows with splits are now invalid.
