### PR TITLE
Use jest-enzyme matchers instead of global type defs

### DIFF
--- a/src/enzymeAdapter.ts
+++ b/src/enzymeAdapter.ts
@@ -1,4 +1,6 @@
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-15';
+import 'jest-enzyme';
+
 
 Enzyme.configure({ adapter: new Adapter() });

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -9,28 +9,6 @@ declare var __webpack_public_path__: string;
 declare var __webpack_require__: { p: string };
 declare var __flow_editor_config__: IFlowEditorConfig;
 
-declare namespace jest {
-    interface Matchers<R> {
-        toBeChecked(): void;
-        toBeDisabled(): void;
-        toBeEmpty(): void;
-        toBePresent(): void;
-        toContainReact(component: React.ReactElement<any>): void;
-        toHaveClassName(className: string): void;
-        toHaveHTML(html: string): void;
-        toHaveProp(propKey: string, propValue?: any): void;
-        toHaveRef(refName: string): void;
-        toHaveState(stateKey: string, stateValue?: any): void;
-        toHaveStyle(styleKey: string, styleValue?: any): void;
-        toHaveTagName(tagName: string): void;
-        toHaveText(text: string): void;
-        toIncludeText(text: string): void;
-        toHaveValue(value: any): void;
-        toMatchElement(element: React.ReactElement<any>): void;
-        toMatchSelector(selector: string): void;
-    }
-}
-
 declare interface Spy {
     (...params: any[]): any;
     identity: string;


### PR DESCRIPTION
This fixes the warnings in vscode for enzyme matchers
<img width="381" alt="screen shot 2017-11-09 at 11 53 46 am" src="https://user-images.githubusercontent.com/211652/32633390-4f675638-c575-11e7-8b72-104fc0f21049.png">
