### PR TITLE
hot load sass w/ css-hot-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1819,6 +1819,16 @@
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
+    "css-hot-loader": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/css-hot-loader/-/css-hot-loader-1.3.4.tgz",
+      "integrity": "sha512-fbqBm1rbwjGhXPrYr2ysc6YHOvqMt5BF3ZTBXiussa7Ti4bukOkwBgzuxjVhqoNNSQUF+xKnRlZrwkJQ89rgcQ==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "normalize-url": "1.9.1"
+      }
+    },
     "css-in-js-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "axios": "^0.15.3",
     "compression-webpack-plugin": "^0.4.0",
     "coveralls": "^3.0.0",
+    "css-hot-loader": "^1.3.4",
     "css-loader": "^0.26.4",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-15": "^1.0.5",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -41,21 +41,23 @@ module.exports = {
             {
                 test: /\.scss$/,
                 include: paths.components,
-                use: ExtractTextPlugin.extract({
-                    fallback: 'style-loader',
-                    use: [
-                        {
-                            loader: 'css-loader',
-                            query: {
-                                modules: true,
-                                sourceMap: true,
-                                importLoaders: 2,
-                                localIdentName: '[name]__[local]___[hash:base64:5]'
-                            }
-                        },
-                        'sass-loader'
-                    ]
-                })
+                use: ['css-hot-loader'].concat(
+                    ExtractTextPlugin.extract({
+                        fallback: 'style-loader',
+                        use: [
+                            {
+                                loader: 'css-loader',
+                                query: {
+                                    modules: true,
+                                    sourceMap: true,
+                                    importLoaders: 2,
+                                    localIdentName: '[name]__[local]___[hash:base64:5]'
+                                }
+                            },
+                            'sass-loader'
+                        ]
+                    })
+                )
             },
             {
                 test: /\.css$/,


### PR DESCRIPTION
- Enables a level of hot loading for our Sass files, more [here](https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/384). 
- Unfortunately, even with this workaround, hot reloading Sass variables is pretty slow. I could be missing something there. 
- I think we should eventually work toward using only `style-loader`/`css-loader`/`sass-loader` to bundle Sass files in development (better support for HMR) and `extract-text-webpack-plugin` in production. 