### PR TITLE
Determine type config fix

### DIFF
--- a/src/components/NodeEditor/NodeEditor.tsx
+++ b/src/components/NodeEditor/NodeEditor.tsx
@@ -211,7 +211,7 @@ export default class NodeEditor extends React.PureComponent<NodeEditorProps, Nod
             }
         }
 
-        // Account for drag (ghost) nodes
+        // Account for ghost nodes
         if (this.props.node) {
             if (this.props.node.router) {
                 return this.props.node.router.type;

--- a/src/components/NodeEditor/NodeEditor.tsx
+++ b/src/components/NodeEditor/NodeEditor.tsx
@@ -211,9 +211,14 @@ export default class NodeEditor extends React.PureComponent<NodeEditorProps, Nod
             }
         }
 
+        // Account for drag (ghost) nodes
         if (this.props.node) {
             if (this.props.node.router) {
                 return this.props.node.router.type;
+            }
+
+            if (this.props.node.actions) {
+                return this.props.node.actions[0].type;
             }
         }
 
@@ -294,7 +299,6 @@ export default class NodeEditor extends React.PureComponent<NodeEditorProps, Nod
                     (localizedObject: LocalizedObject) =>
                         localizedObject.getObject().uuid === exitUUID
                 );
-
 
                 if (localized) {
                     let value = '';


### PR DESCRIPTION
Adds a block to account for the ghost node `Flow` creates when user attempts to drag a new node from a router. 