### PR TITLE
Create expiration route when calling out to a flow

### DIFF
--- a/assets/flows/a4f64f1b-85bc-477e-b706-de313a022979.json
+++ b/assets/flows/a4f64f1b-85bc-477e-b706-de313a022979.json
@@ -274,6 +274,12 @@
                                     "type": "has_run_status",
                                     "arguments": ["C"],
                                     "exit_uuid": "8c867b8f-f311-4b02-b36b-3688964bdc69"
+                                },
+                                {
+                                    "uuid": "b46ffd80-1b85-44bf-b3f2-01550d4ff302",
+                                    "type": "has_run_status",
+                                    "arguments": ["E"],
+                                    "exit_uuid": "1a81edc4-5f8c-4115-92ef-834dac61c2e7"
                                 }
                             ],
                             "default_exit_uuid": null
@@ -282,6 +288,11 @@
                             {
                                 "uuid": "8c867b8f-f311-4b02-b36b-3688964bdc69",
                                 "name": "Complete",
+                                "destination_node_uuid": null
+                            },
+                            {
+                                "uuid": "1a81edc4-5f8c-4115-92ef-834dac61c2e7",
+                                "name": "Expired",
                                 "destination_node_uuid": null
                             }
                         ],

--- a/src/component/NodeEditor/NodeEditor.test.tsx
+++ b/src/component/NodeEditor/NodeEditor.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import CompMap from '../../services/ComponentMap';
 import NodeEditor, { NodeEditorProps, mapExits, isSwitchForm, getAction } from './index';
 import { getBaseLanguage } from '../';
 import { V4_UUID } from '../../utils';
-import { getTypeConfig, typeConfigList } from '../../config';
+import { getTypeConfig, typeConfigList, endpointsPT } from '../../config';
 import { WaitType } from '../../flowTypes';
 import { resolveExits, hasWait, hasCases, groupsToCases } from './NodeEditor';
 import { extractGroups } from '../routers/GroupRouter';
@@ -12,11 +12,12 @@ import { extractGroups } from '../routers/GroupRouter';
 const {
     results: [{ definition }]
 } = require('../../../assets/flows/a4f64f1b-85bc-477e-b706-de313a022979.json');
-const { languages } = require('../../../assets/config');
+const { languages, endpoints } = require('../../../assets/config');
 
-const { nodes: [node], language: flowLanguage } = definition;
+const { nodes: [replyNode, , , , , , subflowRouterNode], language: flowLanguage } = definition;
 
-const { actions: [replyAction] } = node;
+const { actions: [replyAction] } = replyNode;
+const { actions: [startFlowAction] } = subflowRouterNode;
 
 const switchNode = {
     uuid: 'bc978e00-2f3d-41f2-87c1-26b3f14e5925',
@@ -57,7 +58,7 @@ const nodeEditorProps: NodeEditorProps = {
     translating: false,
     show: true,
     definition,
-    node,
+    node: replyNode,
     action: replyAction,
     onUpdateAction: jest.fn(),
     onUpdateRouter: jest.fn(),
@@ -104,7 +105,7 @@ describe('NodeEditor >', () => {
             });
 
             it('should return false if node does not have wait', () => {
-                expect(hasWait(node)).toBeFalsy();
+                expect(hasWait(replyNode)).toBeFalsy();
             });
         });
 
@@ -124,18 +125,15 @@ describe('NodeEditor >', () => {
 
         describe('isSwitchForm >', () => {
             it('should return true if argument is a type that maps to a switch router form, false otherwise', () => {
-                [
-                    'wait_for_response',
-                    'split_by_expression',
-                    'split_by_group',
-                    'reply'
-                ].forEach((type, idx, arr) => {
-                    if (idx === arr.length - 1) {
-                        expect(isSwitchForm(type)).toBeFalsy();
-                    } else {
-                        expect(isSwitchForm(type)).toBeTruthy();
+                ['wait_for_response', 'split_by_expression', 'split_by_group', 'reply'].forEach(
+                    (type, idx, arr) => {
+                        if (idx === arr.length - 1) {
+                            expect(isSwitchForm(type)).toBeFalsy();
+                        } else {
+                            expect(isSwitchForm(type)).toBeTruthy();
+                        }
                     }
-                });
+                );
             });
         });
 
@@ -222,6 +220,135 @@ describe('NodeEditor >', () => {
                     <div className="advanced_title">Advanced Settings</div>
                 </div>
             ]);
+        });
+    });
+
+    describe('instance methods >', () => {
+        describe('updateSubflowRouter >', () => {
+            it("it should call 'updateRouter' with the existing exit, cases if node exists and is of type 'subflow'", () => {
+                const updateRouterSpy = jest.spyOn(NodeEditor.prototype, 'updateRouter');
+                const updateSubflowRouterSpy = jest.spyOn(
+                    NodeEditor.prototype,
+                    'updateSubflowRouter'
+                );
+
+                const wrapper = mount(
+                    <NodeEditor
+                        language={getBaseLanguage(languages)}
+                        translating={false}
+                        show={true}
+                        definition={definition}
+                        node={subflowRouterNode}
+                        action={startFlowAction}
+                        onUpdateAction={jest.fn()}
+                        onUpdateRouter={jest.fn()}
+                        onUpdateLocalizations={jest.fn()}
+                        ComponentMap={ComponentMap}
+                    />,
+                    {
+                        context: { endpoints },
+                        childContextTypes: {
+                            endpoints: endpointsPT
+                        }
+                    }
+                );
+
+                wrapper.instance().submit();
+
+                expect(updateSubflowRouterSpy).toHaveBeenCalled();
+                expect(updateRouterSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        router: expect.objectContaining({
+                            cases: subflowRouterNode.router.cases
+                        }),
+                        exits: subflowRouterNode.exits
+                    }),
+                    'subflow',
+                    startFlowAction
+                );
+
+                updateSubflowRouterSpy.mockRestore();
+                updateRouterSpy.mockRestore();
+            });
+        });
+
+        it("it should call 'updateRouter' with the new exit, cases if node exists but is not of type 'subflow'", () => {
+            const updateRouterSpy = jest.spyOn(NodeEditor.prototype, 'updateRouter');
+            const updateSubflowRouterSpy = jest.spyOn(NodeEditor.prototype, 'updateSubflowRouter');
+
+            const wrapper = mount(
+                <NodeEditor
+                    language={getBaseLanguage(languages)}
+                    translating={false}
+                    show={true}
+                    definition={definition}
+                    node={replyNode}
+                    action={startFlowAction}
+                    onUpdateAction={jest.fn()}
+                    onUpdateRouter={jest.fn()}
+                    onUpdateLocalizations={jest.fn()}
+                    ComponentMap={ComponentMap}
+                />,
+                {
+                    context: { endpoints },
+                    childContextTypes: {
+                        endpoints: endpointsPT
+                    }
+                }
+            );
+
+            wrapper.setState({ config: getTypeConfig('start_flow') });
+
+            expect(wrapper.state('config')).toEqual(
+                expect.objectContaining({
+                    type: 'start_flow'
+                })
+            );
+
+            expect(wrapper.find('SubflowRouter').prop('updateRouter')).toEqual(
+                wrapper.instance().updateSubflowRouter
+            );
+
+            wrapper.instance().submit();
+
+            expect(updateSubflowRouterSpy).toHaveBeenCalled();
+            expect(updateRouterSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    router: expect.objectContaining({
+                        cases: expect.arrayContaining([
+                            {
+                                uuid: expect.stringMatching(V4_UUID),
+                                type: 'has_run_status',
+                                arguments: ['C'],
+                                exit_uuid: expect.stringMatching(V4_UUID)
+                            },
+                            {
+                                uuid: expect.stringMatching(V4_UUID),
+                                type: 'has_run_status',
+                                arguments: ['E'],
+                                exit_uuid: expect.stringMatching(V4_UUID)
+                            }
+                        ])
+                    }),
+                    exits: expect.arrayContaining([
+                        {
+                            uuid: expect.stringMatching(V4_UUID),
+                            name: 'Complete',
+                            destination_node_uuid: null
+                        },
+                        {
+                            uuid: expect.stringMatching(V4_UUID),
+                            name: 'Expired',
+                            destination_node_uuid: null
+                        }
+                    ])
+                }),
+                'subflow',
+                startFlowAction
+            );
+
+            updateRouterSpy.mockRestore();
+            updateSubflowRouterSpy.mockRestore();
         });
     });
 });

--- a/src/component/NodeEditor/NodeEditor.test.tsx
+++ b/src/component/NodeEditor/NodeEditor.test.tsx
@@ -253,7 +253,7 @@ describe('NodeEditor >', () => {
                     }
                 );
 
-                wrapper.instance().submit();
+                (wrapper.instance() as NodeEditor).submit();
 
                 expect(updateSubflowRouterSpy).toHaveBeenCalled();
                 expect(updateRouterSpy).toHaveBeenCalledWith(
@@ -297,6 +297,7 @@ describe('NodeEditor >', () => {
                 }
             );
 
+            const nodeEditor = wrapper.instance() as NodeEditor;
             wrapper.setState({ config: getTypeConfig('start_flow') });
 
             expect(wrapper.state('config')).toEqual(
@@ -305,11 +306,8 @@ describe('NodeEditor >', () => {
                 })
             );
 
-            expect(wrapper.find('SubflowRouter').prop('updateRouter')).toEqual(
-                wrapper.instance().updateSubflowRouter
-            );
-
-            wrapper.instance().submit();
+            expect(wrapper.find('SubflowRouter').prop('updateRouter')).toEqual(nodeEditor.updateSubflowRouter);
+            nodeEditor.submit();
 
             expect(updateSubflowRouterSpy).toHaveBeenCalled();
             expect(updateRouterSpy).toHaveBeenCalledWith(

--- a/src/component/NodeEditor/NodeEditor.tsx
+++ b/src/component/NodeEditor/NodeEditor.tsx
@@ -806,7 +806,7 @@ export default class NodeEditor extends React.PureComponent<NodeEditorProps, Nod
         this.props.onUpdateAction(this.props.node, act);
     }
 
-    private updateRouter(node: Node, type: string, previousAction?: Action): void {
+    public updateRouter(node: Node, type: string, previousAction?: Action): void {
         this.props.onUpdateRouter(node, type, previousAction);
     }
 
@@ -893,7 +893,7 @@ export default class NodeEditor extends React.PureComponent<NodeEditorProps, Nod
         );
     }
 
-    private updateSubflowRouter(): void {
+    public updateSubflowRouter(): void {
         const action = getAction(this.props, this.state.config);
         const select = this.widgets.Flow;
         const { name: flowName, id: flowUUID } = select.state.flow;
@@ -926,7 +926,7 @@ export default class NodeEditor extends React.PureComponent<NodeEditorProps, Nod
                     uuid: generateUUID(),
                     name: 'Expired',
                     destination_node_uuid: null
-                },
+                }
             ];
 
             cases = [

--- a/src/component/NodeEditor/NodeEditor.tsx
+++ b/src/component/NodeEditor/NodeEditor.tsx
@@ -921,7 +921,12 @@ export default class NodeEditor extends React.PureComponent<NodeEditorProps, Nod
                     uuid: generateUUID(),
                     name: 'Complete',
                     destination_node_uuid: null
-                }
+                },
+                {
+                    uuid: generateUUID(),
+                    name: 'Expired',
+                    destination_node_uuid: null
+                },
             ];
 
             cases = [
@@ -930,6 +935,12 @@ export default class NodeEditor extends React.PureComponent<NodeEditorProps, Nod
                     type: 'has_run_status',
                     arguments: ['C'],
                     exit_uuid: exits[0].uuid
+                },
+                {
+                    uuid: generateUUID(),
+                    type: 'has_run_status',
+                    arguments: ['E'],
+                    exit_uuid: exits[1].uuid
                 }
             ];
         }

--- a/src/component/form/FlowElement.tsx
+++ b/src/component/form/FlowElement.tsx
@@ -24,13 +24,14 @@ export default class FlowElement extends React.Component<FlowElementProps, FlowS
     constructor(props: any) {
         super(props);
 
-        const flow: SearchResult = this.props.flow_uuid
-            ? {
-                  name: this.props.flow_name,
-                  id: this.props.flow_uuid,
-                  type: 'flow'
-              }
-            : null;
+        const flow =
+            this.props.flow_uuid && this.props.flow_name
+                ? {
+                      name: this.props.flow_name,
+                      id: this.props.flow_uuid,
+                      type: 'flow'
+                  }
+                : null;
 
         this.state = {
             flow,


### PR DESCRIPTION
Fixes nyaruka/floweditor/issues/113

@ycleptkellan could use a hand with the proper way to test `updateSubflowRouter` to ensure it creates the correct exits. Or this presumably is easier with redux?