### PR TITLE
Rename Node to FlowNode to avoid colliding with dom

### DIFF
--- a/src/component/Exit.tsx
+++ b/src/component/Exit.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { ConfigProviderContext, languagesPT } from '../config';
-import { Exit, LocalizationMap, Node } from '../flowTypes';
+import { Exit, LocalizationMap, FlowNode } from '../flowTypes';
 import ActivityManager from '../services/ActivityManager';
 import { AppState, DisconnectExit, disconnectExit, DispatchWithState } from '../store';
 import { createClickHandler, getLocalization } from '../utils';
@@ -16,7 +16,7 @@ import { Language } from './LanguageSelector';
 
 export interface ExitPassedProps {
     exit: Exit;
-    node: Node;
+    node: FlowNode;
     Activity: ActivityManager;
     plumberMakeSource: Function;
     plumberRemove: Function;

--- a/src/component/Flow.tsx
+++ b/src/component/Flow.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { ConfigProviderContext, languagesPT } from '../config';
 import { getActivity } from '../external';
-import { FlowDefinition, Languages, Node, UINode } from '../flowTypes';
+import { FlowDefinition, Languages, FlowNode, UINode } from '../flowTypes';
 import ActivityManager from '../services/ActivityManager';
 import Plumber from '../services/Plumber';
 import {
@@ -35,7 +35,7 @@ export interface FlowStoreProps {
     definition: FlowDefinition;
     nodes: { [uuid: string]: RenderNode };
     dependencies: FlowDefinition[];
-    ghostNode: Node;
+    ghostNode: FlowNode;
     pendingConnection: DragPoint;
     nodeEditorOpen: boolean;
     ensureStartNode: NoParamsAC;

--- a/src/component/Modal.tsx
+++ b/src/component/Modal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactModal from 'react-modal';
-import { Case, Node, SwitchRouter } from '../flowTypes';
+import { Case, FlowNode, SwitchRouter } from '../flowTypes';
 import Button, { ButtonProps, ButtonTypes } from './Button';
 import * as styles from './Modal.scss';
 import * as shared from './shared.scss';
@@ -23,7 +23,7 @@ interface CustomStyles {
 export interface ModalProps {
     show: boolean;
     buttons: ButtonSet;
-    node?: Node;
+    node?: FlowNode;
     advanced?: JSX.Element;
     onModalOpen?: any;
     __className?: string;
@@ -143,7 +143,8 @@ export default class Modal extends React.PureComponent<ModalProps, ModalState> {
                         <div
                             className={`${styles.header} ${this.props.__className} ${
                                 shared[`modal_side_${childIdx}`]
-                            }`}>
+                            }`}
+                        >
                             {flip}
                             {title}
                         </div>
@@ -187,7 +188,8 @@ export default class Modal extends React.PureComponent<ModalProps, ModalState> {
                 onRequestClose={onRequestClose}
                 style={customStyles}
                 shouldCloseOnOverlayClick={false}
-                contentLabel="Modal">
+                contentLabel="Modal"
+            >
                 <div className={topStyle}>{sides}</div>
             </ReactModal>
         );

--- a/src/component/Node.tsx
+++ b/src/component/Node.tsx
@@ -8,7 +8,7 @@ import * as FlipMove from 'react-flip-move';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { ConfigProviderContext, getTypeConfig, languagesPT } from '../config';
-import { AnyAction, FlowDefinition, Node, SwitchRouter, UINode } from '../flowTypes';
+import { AnyAction, FlowDefinition, FlowNode, SwitchRouter, UINode } from '../flowTypes';
 import ActivityManager from '../services/ActivityManager';
 import { DragEvent } from '../services/Plumber';
 import {
@@ -50,7 +50,7 @@ export interface DragPoint {
 }
 
 export interface NodePassedProps {
-    node: Node;
+    node: FlowNode;
     ui: UINode;
     Activity: ActivityManager;
     plumberRepaintForDuration: Function;

--- a/src/component/NodeEditor/NodeEditor.tsx
+++ b/src/component/NodeEditor/NodeEditor.tsx
@@ -16,7 +16,7 @@ import {
     Exit,
     FlowDefinition,
     Methods,
-    Node,
+    FlowNode,
     Router,
     SendEmail,
     SendMsg,
@@ -83,7 +83,7 @@ export interface NodeEditorPassedProps {
 }
 
 export interface NodeEditorStoreProps {
-    nodeToEdit: Node;
+    nodeToEdit: FlowNode;
     language: Language;
     nodeEditorOpen: boolean;
     actionToEdit: Action;
@@ -149,7 +149,7 @@ export const mapExits = (exits: Exit[]): { [uuid: string]: Exit } =>
 export const isSwitchForm = (type: string) =>
     type === 'wait_for_response' || type === 'split_by_expression' || type === 'split_by_groups';
 
-export const hasSwitchRouter = (node: Node): boolean =>
+export const hasSwitchRouter = (node: FlowNode): boolean =>
     (node.router as SwitchRouter) && (node.router as SwitchRouter).hasOwnProperty('operand');
 
 /**
@@ -220,7 +220,7 @@ export const getAction = (actionToEdit: AnyAction, typeConfig: Type): AnyAction 
  * Given a set of cases and previous exits, determines correct merging of cases
  * and the union of exits
  */
-export const resolveExits = (newCases: CaseElementProps[], previous: Node): CombinedExits => {
+export const resolveExits = (newCases: CaseElementProps[], previous: FlowNode): CombinedExits => {
     // create mapping of our old exit uuids to old exit settings
     const previousExitMap: { [uuid: string]: Exit } = {};
 
@@ -333,7 +333,7 @@ export const resolveExits = (newCases: CaseElementProps[], previous: Node): Comb
     return { cases, exits, defaultExit: defaultUUID };
 };
 
-export const hasCases = (node: Node): boolean => {
+export const hasCases = (node: FlowNode): boolean => {
     if (
         node.router &&
         (node.router as SwitchRouter).cases &&
@@ -347,7 +347,7 @@ export const hasCases = (node: Node): boolean => {
 /**
  * Determine whether Node has a 'wait' property
  */
-export const hasWait = (node: Node, type?: WaitType): boolean => {
+export const hasWait = (node: FlowNode, type?: WaitType): boolean => {
     if (!node || !node.wait || !node.wait.type || (type && node.wait.type !== type)) {
         return false;
     }
@@ -493,7 +493,8 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
                 <span
                     data-spec="name-field"
                     className={formStyles.saveLink}
-                    onClick={this.onShowNameField}>
+                    onClick={this.onShowNameField}
+                >
                     Save as..
                 </span>
             );
@@ -776,7 +777,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
             optionalRouter.result_name = this.props.resultName;
         }
 
-        const optionalNode: Pick<Node, 'wait'> = {};
+        const optionalNode: Pick<FlowNode, 'wait'> = {};
         if (this.props.typeConfig.type === 'wait_for_response') {
             optionalNode.wait = { type: WaitType.msg };
         } else if (this.props.typeConfig.type === 'split_by_expression') {
@@ -826,7 +827,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
             result_name: ''
         };
 
-        const updates: Partial<Node> = {
+        const updates: Partial<FlowNode> = {
             uuid: this.props.nodeToEdit.uuid,
             exits,
             wait: {
@@ -839,7 +840,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
         }
 
         this.props.onUpdateRouter(
-            { ...updates, router } as Node,
+            { ...updates, router } as FlowNode,
             'split_by_groups',
             this.props.plumberRepaintForDuration,
             getAction(this.props.actionToEdit, this.props.typeConfig)
@@ -1161,7 +1162,8 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
                 <FormContainer
                     key={'fc-back'}
                     onKeyPress={this.onKeyPress}
-                    __className={formStyles.advanced}>
+                    __className={formStyles.advanced}
+                >
                     <FormComp ref={this.formRef} {...{ ...formProps, showAdvanced: true }} />
                 </FormContainer>
             );
@@ -1188,7 +1190,8 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
                         title={titles}
                         show={this.props.nodeEditorOpen}
                         buttons={buttons}
-                        node={this.props.nodeToEdit}>
+                        node={this.props.nodeToEdit}
+                    >
                         {front}
                         {back}
                     </Modal>

--- a/src/component/actions/Action/Action.tsx
+++ b/src/component/actions/Action/Action.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getTypeConfig, languagesPT } from '../../../config';
 import { ConfigProviderContext } from '../../../config/ConfigProvider';
-import { AnyAction, Node, LocalizationMap } from '../../../flowTypes';
+import { AnyAction, FlowNode, LocalizationMap } from '../../../flowTypes';
 import { LocalizedObject } from '../../../services/Localization';
 import {
     ActionAC,
@@ -31,7 +31,7 @@ export interface ActionWrapperPassedProps {
 }
 
 export interface ActionWrapperStoreProps {
-    node: Node;
+    node: FlowNode;
     language: Language;
     translating: boolean;
     onOpenNodeEditor: OnOpenNodeEditor;

--- a/src/component/routers/GroupsRouter.tsx
+++ b/src/component/routers/GroupsRouter.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { endpointsPT } from '../../config';
-import { Node, SwitchRouter, WaitType } from '../../flowTypes';
+import { FlowNode, SwitchRouter, WaitType } from '../../flowTypes';
 import { AppState, SearchResult } from '../../store';
 import GroupsElement, { GroupsElementProps } from '../form/GroupsElement';
 import { GetResultNameField } from '../NodeEditor';
@@ -12,7 +12,7 @@ import * as styles from './SwitchRouter.scss';
 export interface GroupsRouterStoreProps {
     translating: boolean;
     localGroups: SearchResult[];
-    nodeToEdit: Node;
+    nodeToEdit: FlowNode;
 }
 
 export interface GroupsRouterPassedProps {
@@ -25,7 +25,7 @@ export interface GroupsRouterPassedProps {
 
 export type GroupsRouterProps = GroupsRouterStoreProps & GroupsRouterPassedProps;
 
-export const extractGroups = ({ exits, router }: Node): SearchResult[] =>
+export const extractGroups = ({ exits, router }: FlowNode): SearchResult[] =>
     (router as SwitchRouter).cases.map(kase => {
         let resultName = '';
         for (const { name, uuid } of exits) {
@@ -37,7 +37,7 @@ export const extractGroups = ({ exits, router }: Node): SearchResult[] =>
         return { name: resultName, id: kase.arguments[0] };
     });
 
-export const hasGroupsRouter = (node: Node) =>
+export const hasGroupsRouter = (node: FlowNode) =>
     hasSwitchRouter(node) && hasWait(node, WaitType.group);
 
 export class GroupsRouter extends React.Component<GroupsRouterProps> {

--- a/src/component/routers/SwitchRouter.tsx
+++ b/src/component/routers/SwitchRouter.tsx
@@ -5,7 +5,7 @@ import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
 import { connect } from 'react-redux';
 import { v4 as generateUUID } from 'uuid';
 import { getOperatorConfig, operatorConfigList, Type } from '../../config';
-import { Case, Exit, Node, SwitchRouter } from '../../flowTypes';
+import { Case, Exit, FlowNode, SwitchRouter } from '../../flowTypes';
 import { AppState } from '../../store';
 import { LocalizedObject } from '../../services/Localization';
 import { reorderList } from '../../utils';
@@ -33,7 +33,7 @@ export interface SwitchRouterStoreProps {
     language: Language;
     typeConfig: Type;
     translating: boolean;
-    nodeToEdit: Node;
+    nodeToEdit: FlowNode;
     localizations: LocalizedObject[];
     operand: string;
 }
@@ -327,7 +327,8 @@ export class SwitchRouterForm extends React.Component<SwitchRouterProps, SwitchR
                                                 provided.draggableStyle,
                                                 snapshot.isDragging
                                             )}
-                                            {...provided.dragHandleProps}>
+                                            {...provided.dragHandleProps}
+                                        >
                                             <CaseElement
                                                 data-spec="case"
                                                 ref={this.props.onBindWidget}
@@ -473,7 +474,8 @@ export class SwitchRouterForm extends React.Component<SwitchRouterProps, SwitchR
                                     style={getListStyle(
                                         isDraggingOver,
                                         draggableCases.length === 1
-                                    )}>
+                                    )}
+                                >
                                     {draggableCases}
                                     {placeholder}
                                 </div>
@@ -515,7 +517,8 @@ export class SwitchRouterForm extends React.Component<SwitchRouterProps, SwitchR
                 </div>
                 <div
                     data-spec="advanced-instructions"
-                    className={styles.translatingOperatorInstructions}>
+                    className={styles.translatingOperatorInstructions}
+                >
                     {OPERAND_LOCALIZATION_DESC}
                 </div>
                 {operands}

--- a/src/flowTypes.ts
+++ b/src/flowTypes.ts
@@ -29,12 +29,12 @@ export interface FlowDefinition {
     localization: LocalizationMap;
     language: string;
     name: string;
-    nodes: Node[];
+    nodes: FlowNode[];
     uuid: string;
     _ui: UIMetaData;
 }
 
-export interface Node {
+export interface FlowNode {
     uuid: string;
     exits: Exit[];
     router?: Router;

--- a/src/services/Plumber.ts
+++ b/src/services/Plumber.ts
@@ -1,5 +1,5 @@
 const { jsPlumb: { importDefaults } } = require('../../node_modules/jsplumb/dist/js/jsplumb');
-import { Node, FlowDefinition, Exit, LocalizationMap } from '../flowTypes';
+import { FlowNode, FlowDefinition, Exit, LocalizationMap } from '../flowTypes';
 
 export interface DragEvent {
     el: Element;
@@ -136,11 +136,11 @@ export default class Plumber {
         this.jsPlumb.makeTarget(uuid, TARGET_DEFAULTS);
     }
 
-    public connectExit(node: Node, exit: Exit, className: string = null): void {
+    public connectExit(node: FlowNode, exit: Exit, className: string = null): void {
         this.connect(`${node.uuid}:${exit.uuid}`, exit.destination_node_uuid, className);
     }
 
-    public setDragSelection(nodes: Node[]): void {
+    public setDragSelection(nodes: FlowNode[]): void {
         this.cancelDurationRepaint();
         this.jsPlumb.clearDragSelection();
         nodes.forEach(({ uuid }) => this.jsPlumb.addToDragSelection(uuid));

--- a/src/store/actionTypes.ts
+++ b/src/store/actionTypes.ts
@@ -1,7 +1,7 @@
 import { Language } from '../component/LanguageSelector';
 import { DragPoint } from '../component/Node';
 import { Type } from '../config';
-import { AnyAction, FlowDefinition, Node, Position } from '../flowTypes';
+import { AnyAction, FlowDefinition, FlowNode, Position } from '../flowTypes';
 import { LocalizedObject } from '../services/Localization';
 import Constants from './constants';
 import { CompletionOption, RenderNode, SearchResult } from './flowContext';
@@ -71,7 +71,7 @@ interface UpdateNodeEditorOpenPayload {
 }
 
 interface UpdateGhostNodePayload {
-    ghostNode: Node;
+    ghostNode: FlowNode;
 }
 
 interface UpdateCreateNodePositionPayload {
@@ -87,7 +87,7 @@ interface UpdateActionToEditPayload {
 }
 
 interface UpdateNodeToEditPayload {
-    nodeToEdit: Node;
+    nodeToEdit: FlowNode;
 }
 
 interface UpdateLocalizationsPayload {

--- a/src/store/flowContext.ts
+++ b/src/store/flowContext.ts
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux';
 import { v4 as generateUUID } from 'uuid';
-import { FlowDefinition, Node, UINode, AttributeType } from '../flowTypes';
+import { FlowDefinition, FlowNode, UINode, AttributeType } from '../flowTypes';
 import { LocalizedObject } from '../services/Localization';
 import ActionTypes, {
     UpdateContactFieldsAction,
@@ -19,7 +19,7 @@ export interface RenderNodeMap {
 
 export interface RenderNode {
     ui: UINode;
-    node: Node;
+    node: FlowNode;
     inboundConnections?: { [uuid: string]: string };
 }
 

--- a/src/store/flowEditor.ts
+++ b/src/store/flowEditor.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux';
 import { Language } from '../component/LanguageSelector';
 import { DragPoint } from '../component/Node';
-import { Node, Position } from '../flowTypes';
+import { FlowNode, Position } from '../flowTypes';
 import ActionTypes, {
     RemovePendingConnectionAction,
     UpdateCreateNodePositionAction,
@@ -37,7 +37,7 @@ export interface FlowUI {
     pendingConnection: DragPoint;
     pendingConnections: PendingConnections;
     nodeDragging: boolean;
-    ghostNode: Node;
+    ghostNode: FlowNode;
     dragGroup: boolean;
 }
 
@@ -145,7 +145,7 @@ export const removePendingConnection = (nodeUUID: string): RemovePendingConnecti
 });
 
 // tslint:disable-next-line:no-shadowed-variable
-export const updateGhostNode = (ghostNode: Node): UpdateGhostNodeAction => ({
+export const updateGhostNode = (ghostNode: FlowNode): UpdateGhostNodeAction => ({
     type: Constants.UPDATE_GHOST_NODE,
     payload: {
         ghostNode
@@ -288,7 +288,7 @@ export const nodeDragging = (
     }
 };
 
-export const ghostNode = (state: Node = initialState.flowUI.ghostNode, action: ActionTypes) => {
+export const ghostNode = (state: FlowNode = initialState.flowUI.ghostNode, action: ActionTypes) => {
     switch (action.type) {
         case Constants.UPDATE_GHOST_NODE:
             return action.payload.ghostNode;

--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -5,7 +5,7 @@ import {
     FlowDefinition,
     Languages,
     LocalizationMap,
-    Node,
+    FlowNode,
     SwitchRouter,
     WaitType
 } from '../flowTypes';
@@ -63,9 +63,9 @@ export const getExistingFields = (
 export const pureSort = (list: any[], fn: (a: any, b: any) => number) => [...list].sort(fn);
 
 export const getNodesBelow = (
-    { uuid: nodeUUID }: Node,
+    { uuid: nodeUUID }: FlowNode,
     nodes: { [uuid: string]: RenderNode }
-): Node[] => {
+): FlowNode[] => {
     const below = nodes[nodeUUID].ui.position.top;
 
     // TODO: well this isn't great now is it
@@ -105,7 +105,7 @@ export const getTranslations = (localizationMap: LocalizationMap, iso: string) =
     localizationMap[iso];
 
 export const getLocalizations = (
-    node: Node,
+    node: FlowNode,
     action: AnyAction,
     iso: string,
     languages: Languages,
@@ -137,7 +137,7 @@ export const getLocalizations = (
 };
 
 export const determineConfigType = (
-    nodeToEdit: Node,
+    nodeToEdit: FlowNode,
     action: AnyAction,
     nodes: { [uuid: string]: RenderNode }
 ) => {
@@ -168,7 +168,7 @@ export const determineConfigType = (
     throw new Error(`Cannot initialize NodeEditor without a valid type: ${nodeToEdit.uuid}`);
 };
 
-export const getUniqueDestinations = (node: Node): string[] => {
+export const getUniqueDestinations = (node: FlowNode): string[] => {
     const destinations = {};
     for (const exit of node.exits) {
         if (exit.destination_node_uuid) {
@@ -183,7 +183,7 @@ export const getConnectionError = (source: string, targetUUID: string) => {
     return nodeUUID === targetUUID ? 'Connections cannot route back to the same places.' : null;
 };
 
-export const nodeSort = (definition: FlowDefinition) => (a: Node, b: Node) => {
+export const nodeSort = (definition: FlowDefinition) => (a: FlowNode, b: FlowNode) => {
     const { position: aPos } = definition._ui.nodes[a.uuid];
     const { position: bPos } = definition._ui.nodes[b.uuid];
     const diff = aPos.top - bPos.top;
@@ -258,7 +258,7 @@ export const getCollision = (nodes: RenderNodeMap): RenderNode[] => {
 };
 
 export const getGhostNode = (fromNode: RenderNode, nodes: RenderNodeMap) => {
-    const ghostNode: Node = {
+    const ghostNode: FlowNode = {
         uuid: generateUUID(),
         actions: [],
         exits: [

--- a/src/store/mutators.ts
+++ b/src/store/mutators.ts
@@ -1,12 +1,12 @@
 const mutate = require('immutability-helper');
-import { Node, UINode, AnyAction, FlowDefinition, Dimensions } from '../flowTypes';
+import { FlowNode, UINode, AnyAction, FlowDefinition, Dimensions } from '../flowTypes';
 import { v4 as generateUUID } from 'uuid';
 import { RenderNode, RenderNodeMap } from './flowContext';
 import { dump } from '../utils';
 import { getUniqueDestinations } from './helpers';
 import { LocalizationUpdates } from '.';
 
-export const uniquifyNode = (newNode: Node): Node => {
+export const uniquifyNode = (newNode: FlowNode): FlowNode => {
     // Give our node a unique uuid
     return mutate(newNode, { $merge: { uuid: generateUUID() } });
 };
@@ -19,7 +19,7 @@ export const getNode = (nodes: RenderNodeMap, nodeUUID: string) => {
     return node;
 };
 
-export const getExitIndex = (node: Node, exitUUID: string) => {
+export const getExitIndex = (node: FlowNode, exitUUID: string) => {
     for (const [exitIdx, exit] of node.exits.entries()) {
         if (exit.uuid === exitUUID) {
             return exitIdx;
@@ -28,7 +28,7 @@ export const getExitIndex = (node: Node, exitUUID: string) => {
     throw new Error('Cannot find exit ' + exitUUID);
 };
 
-export const getActionIndex = (node: Node, actionUUID: string) => {
+export const getActionIndex = (node: FlowNode, actionUUID: string) => {
     for (const [actionIdx, action] of node.actions.entries()) {
         if (action.uuid === actionUUID) {
             return actionIdx;
@@ -251,7 +251,7 @@ export const moveActionUp = (nodes: RenderNodeMap, nodeUUID: string, actionUUID:
  * @param node
  * @param type
  */
-export const updateNode = (nodes: RenderNodeMap, node: Node, type: string) => {
+export const updateNode = (nodes: RenderNodeMap, node: FlowNode, type: string) => {
     // make sure our node exists
     getNode(nodes, node.uuid);
     return mutate(nodes, {

--- a/src/store/nodeEditor.ts
+++ b/src/store/nodeEditor.ts
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux';
 import { Type } from '../config';
-import { AnyAction, Node } from '../flowTypes';
+import { AnyAction, FlowNode } from '../flowTypes';
 import ActionTypes, {
     UpdateActionToEditAction,
     UpdateNodeToEditAction,
@@ -18,7 +18,7 @@ export interface NodeEditor {
     showResultName: boolean;
     operand: string;
     userAddingAction: boolean;
-    nodeToEdit: Node;
+    nodeToEdit: FlowNode;
     actionToEdit: AnyAction;
 }
 
@@ -79,7 +79,7 @@ export const updateActionToEdit = (actionToEdit: AnyAction): UpdateActionToEditA
 });
 
 // tslint:disable-next-line:no-shadowed-variable
-export const updateNodeToEdit = (nodeToEdit: Node): UpdateNodeToEditAction => ({
+export const updateNodeToEdit = (nodeToEdit: FlowNode): UpdateNodeToEditAction => ({
     type: Constants.UPDATE_NODE_TO_EDIT,
     payload: {
         nodeToEdit
@@ -146,7 +146,7 @@ export const userAddingAction = (
     }
 };
 
-export const nodeToEdit = (state: Node = initialState.nodeToEdit, action: ActionTypes) => {
+export const nodeToEdit = (state: FlowNode = initialState.nodeToEdit, action: ActionTypes) => {
     switch (action.type) {
         case Constants.UPDATE_NODE_TO_EDIT:
             return action.payload.nodeToEdit;

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -12,7 +12,7 @@ import {
     Dimensions,
     FlowDefinition,
     Languages,
-    Node,
+    FlowNode,
     Position,
     SendMsg,
     SwitchRouter
@@ -64,22 +64,22 @@ export type Thunk = (dispatch: DispatchWithState, getState?: GetState) => void;
 export type AsyncThunk = (dispatch: DispatchWithState, getState?: GetState) => Promise<void>;
 
 export type OnNodeBeforeDrag = (
-    node: Node,
+    node: FlowNode,
     plumberSetDragSelection: Function,
     plumberClearDragSelection: Function
 ) => Thunk;
 
-export type ResolvePendingConnection = (node: Node) => Thunk;
+export type ResolvePendingConnection = (node: FlowNode) => Thunk;
 
-export type OnAddAction = (node: Node, languages: Languages) => Thunk;
+export type OnAddAction = (node: FlowNode, languages: Languages) => Thunk;
 
 export type OnNodeMoved = (uuid: string, position: Position, repaintForDuration: Function) => Thunk;
 
-export type OnOpenNodeEditor = (node: Node, action: AnyAction, languages: Languages) => Thunk;
+export type OnOpenNodeEditor = (node: FlowNode, action: AnyAction, languages: Languages) => Thunk;
 
-export type RemoveNode = (nodeToRemove: Node) => Thunk;
+export type RemoveNode = (nodeToRemove: FlowNode) => Thunk;
 
-export type UpdateDimensions = (node: Node, dimensions: Dimensions) => Thunk;
+export type UpdateDimensions = (node: FlowNode, dimensions: Dimensions) => Thunk;
 
 export type FetchFlow = (endpoint: string, uuid: string) => AsyncThunk;
 
@@ -93,14 +93,18 @@ export type OnConnectionDrag = (event: ConnectionEvent) => Thunk;
 
 export type OnUpdateLocalizations = (language: string, changes: LocalizationUpdates) => Thunk;
 
-export type OnUpdateAction = (node: Node, action: AnyAction, repaintForDuration: Function) => Thunk;
+export type OnUpdateAction = (
+    node: FlowNode,
+    action: AnyAction,
+    repaintForDuration: Function
+) => Thunk;
 
 export type ActionAC = (nodeUUID: string, action: AnyAction) => Thunk;
 
 export type DisconnectExit = (nodeUUID: string, exitUUID: string) => Thunk;
 
 export type OnUpdateRouter = (
-    node: Node,
+    node: FlowNode,
     type: string,
     repaintForDuration: Function,
     previousAction?: Action
@@ -247,7 +251,7 @@ export const onUpdateLocalizations = (language: string, changes: LocalizationUpd
     dispatch(updateDefinition(mutators.updateLocalization(definition, language, changes)));
 };
 
-export const updateDimensions = (node: Node, dimensions: Dimensions) => (
+export const updateDimensions = (node: FlowNode, dimensions: Dimensions) => (
     dispatch: DispatchWithState,
     getState: GetState
 ) => {
@@ -296,7 +300,7 @@ export const updateConnection = (source: string, target: string) => (
     dispatch(updateExitDestination(nodeUUID, exitUUID, target));
 };
 
-export const resolvePendingConnection = (node: Node) => (
+export const resolvePendingConnection = (node: FlowNode) => (
     dispatch: DispatchWithState,
     getState: GetState
 ) => {
@@ -325,7 +329,7 @@ export const ensureStartNode = () => (dispatch: DispatchWithState, getState: Get
             text: 'Hi there, this the first message in your flow!'
         };
 
-        const node: Node = {
+        const node: FlowNode = {
             uuid: generateUUID(),
             actions: [initialAction],
             exits: [
@@ -339,7 +343,7 @@ export const ensureStartNode = () => (dispatch: DispatchWithState, getState: Get
     }
 };
 
-export const removeNode = (node: Node) => (dispatch: DispatchWithState, getState: GetState) => {
+export const removeNode = (node: FlowNode) => (dispatch: DispatchWithState, getState: GetState) => {
     const { flowContext: { nodes } } = getState();
     const updatedNodes = mutators.removeNode(nodes, node.uuid);
     dispatch(updateNodes(updatedNodes));
@@ -426,7 +430,7 @@ export const updateAction = (
  */
 export const spliceInRouter = (
     nodeUUID: string,
-    newRouterNode: Node,
+    newRouterNode: FlowNode,
     type: string,
     previousAction: Action
 ) => (dispatch: DispatchWithState, getState: GetState): RenderNode[] => {
@@ -533,7 +537,7 @@ export const spliceInRouter = (
 /**
  * Appends a new node instead of editing the node in place
  */
-export const appendNewRouter = (node: Node, type: string) => (
+export const appendNewRouter = (node: FlowNode, type: string) => (
     dispatch: DispatchWithState,
     getState: GetState
 ) => {
@@ -569,7 +573,7 @@ export const appendNewRouter = (node: Node, type: string) => (
 };
 
 export const updateRouter = (
-    node: Node,
+    node: FlowNode,
     type: string,
     draggedFrom: DragPoint = null,
     newPosition: Position = null,
@@ -609,7 +613,7 @@ export const updateRouter = (
 };
 
 export const onNodeBeforeDrag = (
-    node: Node,
+    node: FlowNode,
     plumberSetDragSelection: Function,
     plumberClearDragSelection: Function
 ) => (dispatch: DispatchWithState, getState: GetState) => {
@@ -654,7 +658,7 @@ export const resetNodeEditingState = () => (dispatch: DispatchWithState, getStat
     }
 };
 
-export const onUpdateAction = (node: Node, action: AnyAction, repaintForDuration: Function) => (
+export const onUpdateAction = (node: FlowNode, action: AnyAction, repaintForDuration: Function) => (
     dispatch: DispatchWithState,
     getState: GetState
 ) => {
@@ -663,7 +667,7 @@ export const onUpdateAction = (node: Node, action: AnyAction, repaintForDuration
     repaintForDuration();
 };
 
-export const onAddAction = (node: Node, languages: Languages) => (
+export const onAddAction = (node: FlowNode, languages: Languages) => (
     dispatch: DispatchWithState,
     getState: GetState
 ) => {
@@ -771,7 +775,7 @@ export const onConnectionDrag = (event: ConnectionEvent) => (
 };
 
 export const onUpdateRouter = (
-    node: Node,
+    node: FlowNode,
     type: string,
     repaintForDuration: Function,
     previousAction?: Action
@@ -791,7 +795,7 @@ export const onUpdateRouter = (
     dispatch(resetNodeEditingState());
 };
 
-export const onOpenNodeEditor = (node: Node, action: AnyAction, languages: Languages) => (
+export const onOpenNodeEditor = (node: FlowNode, action: AnyAction, languages: Languages) => (
     dispatch: DispatchWithState,
     getState: GetState
 ) => {


### PR DESCRIPTION
Don't want every single object in the flow spec prepended with Temba (this TembaExit, TembaCase, etc), just feels weird. Opted to just rename the one problematic one with a real object collision  to `FlowNode`. Open to bigger rename later if we think it matters.. can revisit.

Fixes: #188 
