### PR TITLE
Remove more references to non-test assets

### DIFF
--- a/__mocks__/axios.ts
+++ b/__mocks__/axios.ts
@@ -1,11 +1,10 @@
 const axios = require.requireActual('axios');
 const { endpoints } = require('../assets/config');
-const colorsFlowResp = require('../assets/flows/a4f64f1b-85bc-477e-b706-de313a022979.json');
-const customerServiceFlowResp = require('../assets/flows/9ecc8e84-6b83-442b-a04a-8094d5de997b.json');
-const flowsResp = require('../assets/flows.json');
-const groupsResp = require('../assets/groups.json');
-const contactsResp = require('../assets/contacts.json');
-const fieldsResp = require('../assets/fields.json');
+const boringFlowResp = require('../__test__/assets/flows/boring.json');
+const flowsResp = require('../__test__/assets/flows.json');
+const groupsResp = require('../__test__/assets/groups.json');
+const contactsResp = require('../__test__/assets/contacts.json');
+const fieldsResp = require('../__test__/assets/fields.json');
 
 const getEndpoint = (urlStr: string) => {
     const queryIdx = urlStr.indexOf('?');
@@ -17,10 +16,15 @@ const getEndpoint = (urlStr: string) => {
 };
 const containsUUIDQuery = (urlStr: string) => urlStr.indexOf('uuid=') > -1;
 const resolvePromise = (data: { [key: string]: any }) => Promise.resolve({ data });
-const getUUIDQuery = (urlStr: string) => urlStr.slice(urlStr.indexOf('uuid=')).slice(5, 41);
-
-const { results: [{ uuid: colorsFlowUUID }] } = colorsFlowResp;
-const { results: [{ uuid: customerServiceFlowUUID }] } = customerServiceFlowResp;
+const getUUIDQuery = (urlStr: string) => {
+    for (const param of urlStr.split(/\&|\?/)) {
+        const [key, value] = param.split('=');
+        if (key === 'uuid') {
+            return value;
+        }
+    }
+    return null;
+};
 
 axios.get = jest.fn(url => {
     const { endpoint, containsQuery } = getEndpoint(url);
@@ -29,10 +33,8 @@ axios.get = jest.fn(url => {
             if (containsQuery && containsUUIDQuery(url)) {
                 const uuid = getUUIDQuery(url);
                 switch (uuid) {
-                    case colorsFlowUUID:
-                        return resolvePromise(colorsFlowResp);
-                    case customerServiceFlowUUID:
-                        return resolvePromise(customerServiceFlowResp);
+                    case 'boring':
+                        return resolvePromise(boringFlowResp);
                     default:
                         throw new Error(`Axios mock: UUID query "${uuid}" not found`);
                 }

--- a/__test__/assets/config.js
+++ b/__test__/assets/config.js
@@ -1,0 +1,31 @@
+const config = {
+    flow: 'boring',
+    languages: {
+        eng: 'English',
+        spa: 'Spanish',
+        fre: 'French'
+    }
+};
+
+module.exports =
+    process.env.NODE_ENV === 'production'
+        ? Object.assign({}, config, {
+              endpoints: {
+                  flows: 'flows',
+                  groups: 'groups',
+                  contacts: 'contacts',
+                  fields: 'fields',
+                  activity: '',
+                  engine: ''
+              }
+          })
+        : Object.assign({}, config, {
+              endpoints: {
+                  flows: '/assets/flows.json',
+                  groups: '/assets/groups.json',
+                  contacts: '/assets/contacts.json',
+                  fields: '/assets/fields.json',
+                  activity: '',
+                  engine: ''
+              }
+          });

--- a/__test__/assets/contacts.json
+++ b/__test__/assets/contacts.json
@@ -1,0 +1,64 @@
+{
+   "total":11,
+   "results":[
+      {
+         "name":"Eric Newcomer",
+         "id":"23ff7152-b588-43e4-90de-fda77aeaf7c0",
+         "type": "contact"
+      },
+      {
+         "name":"Norbert Kwizera",
+         "id":"2429d573-80d7-47f8-879f-f2ba442a1bfd",
+         "type": "contact"
+      },
+      {
+         "name":"Nic Pottier",
+         "id":"cdbf9e01-aaa7-4381-8259-ee042447bcac",
+         "type": "contact"
+      },
+      {
+         "name":"Rowan Seymour",
+         "id":"afaba971-8943-4dd8-860b-3561ed4f1fe1",
+         "type": "contact"
+      },
+      {
+         "name":"Evan Wheeler",
+         "id":"5510bddf-01bd-45b5-a519-33b28bac48d0",
+         "type": "contact"
+      },
+      {
+        "name":"Subscribers",
+        "id":"33b28bac-b588-43e4-90de-fda77aeaf7c0",
+        "type":"group"
+      },
+      {
+         "name":"George Fant",
+         "path":"+250788382382",
+         "scheme":"tel",
+         "id":"tel:+250788382382",
+         "type": "urn"
+      },
+      {
+        "name":"Joey Hunt",
+        "path":"1234567890",
+        "scheme":"facebook",
+        "id":"facebook:123457890",
+        "type": "urn"
+      },
+      {
+          "name":"Justin Britt",
+          "path":"11223344",
+          "scheme":"telegram",
+          "id":"telegram:11223344",
+          "type":"urn"
+      },
+      {
+         "name":"Eric Newcomer",
+         "path":"ericnewcomer",
+         "scheme":"twitter",
+         "id":"twitter:ericnewcomer",
+         "type": "urn"
+      }
+   ],
+   "more": "/assets/contacts_2.json"
+}

--- a/__test__/assets/fields.json
+++ b/__test__/assets/fields.json
@@ -1,0 +1,21 @@
+{
+   "total":3,
+   "results":[
+      {
+          "key": "expected_delivery_date",
+          "label": "Expected Delivery Date",
+          "value_type": "text"
+      },
+      {
+         "key":"national_id",
+         "label": "National ID",
+         "value_type": "numeric"
+      },
+      {
+        "key": "number_of_children",
+        "label":"Number of Children",
+         "value_type": "numeric"
+      }
+   ],
+   "more": null
+}

--- a/__test__/assets/flows.json
+++ b/__test__/assets/flows.json
@@ -1,0 +1,11 @@
+{
+    "total": 1,
+    "results":[
+        {
+            "uuid": "boring",
+            "name": "Boring",
+            "type": "flow"
+        }
+    ],
+    "more": null
+ }

--- a/__test__/assets/flows/boring.json
+++ b/__test__/assets/flows/boring.json
@@ -1,0 +1,182 @@
+{
+    "results": [
+        {
+            "name": "Boring",
+            "uuid": "boring",
+            "definition": {
+                "localization": {},
+                "language": "eng",
+                "name": "Boring Flow",
+                "uuid": "boring",
+                "nodes": [
+                    {
+                        "uuid": "node0",
+                        "actions": [
+                            {
+                                "uuid": "node0_action0",
+                                "type": "send_msg",
+                                "text": "Hi there, this is your first action!"
+                            },
+                            {
+                                "uuid": "node0_action1",
+                                "type": "add_contact_groups",
+                                "groups": [
+                                    {
+                                        "uuid": "group_0",
+                                        "name": "Flow Participants"
+                                    }
+                                ]
+                            },
+                            {
+                                "uuid": "node0_action2",
+                                "type": "remove_contact_groups",
+                                "groups": [
+                                    {
+                                        "uuid": "group_1",
+                                        "name": "Nonresponsive"
+                                    }
+                                ]
+                            }
+                        ],
+                        "exits": [
+                            {
+                                "name": null,
+                                "uuid": "node0_exit0",
+                                "destination_node_uuid": "node1"
+                            }
+                        ]
+                    },
+                    {
+                        "uuid": "node1",
+                        "router": {
+                            "type": "switch",
+                            "default_exit_uuid": "node1_exit2",
+                            "cases": [
+                                {
+                                    "uuid": "node1_case0",
+                                    "type": "has_any_word",
+                                    "exit_uuid": "uuid_node1_exit0",
+                                    "arguments": [
+                                        "red"
+                                    ]
+                                },
+                                {
+                                    "uuid": "node1_case1",
+                                    "type": "has_any_word",
+                                    "exit_uuid": "uuid_node1_exit1",
+                                    "arguments": [
+                                        "green"
+                                    ]
+                                }
+                            ],
+                            "operand": "@input",
+                            "result_name": "color"
+                        },
+                        "exits": [
+                            {
+                                "name": "Red",
+                                "uuid": "node1_exit0",
+                                "destination_node_uuid": "node2"
+                            },
+                            {
+                                "name": "Green",
+                                "uuid": "node1_exit1",
+                                "destination_node_uuid": "node2"
+                            },
+                            {
+                                "name": "Other",
+                                "uuid": "node1_exit2",
+                                "destination_node_uuid": "node2"
+                            }
+                        ],
+                        "wait": {
+                            "type": "msg"
+                        }
+                    },
+                    {
+                        "uuid": "node2",
+                        "actions": [
+                            {
+                                "uuid": "node2_action0",
+                                "type": "send_msg",
+                                "text": "This has been really great."
+                            },
+                            {
+                                "uuid": "node2_action1",
+                                "type": "set_contact_field",
+                                "field": { 
+                                    "key": "unknown_field", 
+                                    "name": "Unknown Field"
+                                },
+                                "value": "Some Value"
+                            }
+                        ],
+                        "exits": [
+                            {
+                                "name": null,
+                                "uuid": "node2_exit0",
+                                "destination_node_uuid": "node3"
+                            }
+                        ]
+                    },
+                    {
+                        "uuid": "node3",
+                        "actions": [
+                            {
+                                "uuid": "node3_action0",
+                                "type": "send_msg",
+                                "text": "Thanks for playing!"
+                            }
+                        ],
+                        "exits": [
+                            {
+                                "name": null,
+                                "uuid": "node3_exit0",
+                                "destination_node_uuid": null
+                            }
+                        ]
+                    }
+                ],
+                "_ui": {
+                    "nodes": {
+                        "node0": {
+                            "position": {
+                                "left": 0,
+                                "top": 0,
+                                "right": 220,
+                                "bottom": 254
+                            }
+                        },
+                        "node1": {
+                            "position": {
+                                "left": 0,
+                                "top": 280,
+                                "bottom": 370,
+                                "right": 220
+                            },
+                            "type": "wait_for_response"
+                        },
+                        "node2": {
+                            "position": {
+                                "left": 0,
+                                "top": 400,
+                                "bottom": 498,
+                                "right": 220
+                            }
+                        },
+                        "node3": {
+                            "position": {
+                                "left": 0,
+                                "top": 520,
+                                "bottom": 598,
+                                "right": 220
+                            }
+                        }
+                    },
+                    "languages": [],
+                    "stickies": {}
+                }
+            }
+        }
+    ]
+}

--- a/__test__/assets/groups.json
+++ b/__test__/assets/groups.json
@@ -1,0 +1,26 @@
+{
+   "total": 5,
+   "results":[
+      {
+         "name":"Customers",
+         "uuid":"23ff7152-b588-43e4-90de-fda77aeaf7c0"
+      },
+      {
+         "name":"Unsatisfied Customers",
+         "uuid":"2429d573-80d7-47f8-879f-f2ba442a1bfd"
+      },
+      {
+         "name":"Early Adopters",
+         "uuid":"cdbf9e01-aaa7-4381-8259-ee042447bcac"
+      },
+      {
+         "name":"Testers",
+         "uuid":"afaba971-8943-4dd8-860b-3561ed4f1fe1"
+      },
+      {
+        "name":"Subscribers",
+        "uuid":"33b28bac-b588-43e4-90de-fda77aeaf7c0"
+      }
+   ],
+   "more": null
+}

--- a/assets/flows.json
+++ b/assets/flows.json
@@ -1,5 +1,5 @@
 {
-    "total": 2,
+    "total": 4,
     "results":[
         {
             "uuid": "a4f64f1b-85bc-477e-b706-de313a022979",

--- a/src/component/Flow.test.ts
+++ b/src/component/Flow.test.ts
@@ -20,7 +20,7 @@ import { FlowDefinition } from '../flowTypes';
 import ActivityManager from '../services/ActivityManager';
 import Plumber from '../services/Plumber';
 import { ConnectionEvent, createStore, initialState } from '../store';
-import { getCollisions, getGhostNode, getFlowDetails } from '../store/helpers';
+import { getCollisions, getGhostNode, getFlowComponents } from '../store/helpers';
 import { createSetup, createSpy, getSpecWrapper } from '../testUtils';
 import { getBaseLanguage, dump } from '../utils';
 
@@ -59,12 +59,12 @@ const childContextTypes = {
     languages: languagesPT
 };
 
-const { renderNodeMap } = getFlowDetails(definition);
+const { renderNodeMap: initialNodes } = getFlowComponents(definition);
 
 const baseProps: FlowStoreProps = {
     translating: false,
     definition,
-    nodes: renderNodeMap,
+    nodes: initialNodes,
     dependencies: [],
     ghostNode: null,
     pendingConnection: null,

--- a/src/component/FlowList.test.ts
+++ b/src/component/FlowList.test.ts
@@ -11,19 +11,16 @@ import {
 } from './FlowList';
 import { FlowEditorConfig } from '../flowTypes';
 
-const config = require('../../assets/config') as FlowEditorConfig;
-const colorsFlowResp = require('../../assets/flows/a4f64f1b-85bc-477e-b706-de313a022979.json') as Resp;
-const customerServiceFlowResp = require('../../assets/flows/9ecc8e84-6b83-442b-a04a-8094d5de997b.json');
-const flowsResp = require('../../assets/flows.json');
+const config = require('../../__test__/assets/config') as FlowEditorConfig;
+const flowsResp = require('../../__test__/assets/flows.json');
 
 const context = {
-    assetHost: config.assetHost,
     endpoints: config.endpoints
 };
 
 const baseProps = {
-    flowUUID: colorsFlowResp.results[0].uuid,
-    flowName: colorsFlowResp.results[0].name,
+    flowUUID: 'boring',
+    flowName: 'Boring',
     flows: flowsResp.results,
     fetchFlow: jest.fn()
 };
@@ -36,8 +33,8 @@ describe(`${COMPONENT_TO_TEST}`, () => {
     describe('helpers', () => {
         describe('getFlowOption', () => {
             it('should return a FlowOption map', () => {
-                const flowUUID = colorsFlowResp.results[0].uuid;
-                const flowName = colorsFlowResp.results[0].name;
+                const flowUUID = 'boring';
+                const flowName = 'Boring';
                 const truthyOption = getFlowOption(flowUUID, flowName);
                 const falsyOption = getFlowOption(undefined, undefined);
 
@@ -56,8 +53,8 @@ describe(`${COMPONENT_TO_TEST}`, () => {
 
         describe('shouldDisplayLoading', () => {
             it('should return true if flow option is not valid or flows prop is falsy', () => {
-                const flowUUID = colorsFlowResp.results[0].uuid;
-                const flowName = colorsFlowResp.results[0].name;
+                const flowUUID = 'boring';
+                const flowName = 'Boring';
                 const validFlowOption = getFlowOption(flowUUID, flowName);
                 const invalidFlowOption = getFlowOption(undefined, undefined);
                 const flows = flowsResp.results;
@@ -67,8 +64,8 @@ describe(`${COMPONENT_TO_TEST}`, () => {
             });
 
             it('should return false if flow option is valid and flows prop is truthy', () => {
-                const flowUUID = colorsFlowResp.results[0].uuid;
-                const flowName = colorsFlowResp.results[0].name;
+                const flowUUID = 'boring';
+                const flowName = 'Boring';
                 const validFlowOption = getFlowOption(flowUUID, flowName);
                 const flows = flowsResp.results;
 
@@ -112,7 +109,7 @@ describe(`${COMPONENT_TO_TEST}`, () => {
                     props: { fetchFlow: fetchFlowMock },
                     context: { endpoints }
                 } = setup({ fetchFlow: jest.fn() }, true);
-                const otherUUID = customerServiceFlowResp.results[0].uuid;
+                const otherUUID = 'other_uuid';
 
                 instance.onChange({ uuid: otherUUID });
 
@@ -123,21 +120,21 @@ describe(`${COMPONENT_TO_TEST}`, () => {
             it('should not call action creator that fetches flow', () => {
                 let {
                     wrapper,
+                    // tslint:disable-next-line:prefer-const
                     instance,
                     props: { fetchFlow: fetchFlowMock },
                     context: { endpoints }
                 } = setup({ flows: [], fetchFlow: jest.fn() }, true);
-                const otherUUID = customerServiceFlowResp.results[0].uuid;
+                const otherUUID = 'other_uuid';
 
                 instance.onChange({ uuid: otherUUID });
 
                 expect(fetchFlowMock).toHaveBeenCalledTimes(0);
 
-                ({
-                    wrapper,
-                    props: { fetchFlow: fetchFlowMock },
-                    context: { endpoints }
-                } = setup({}, true));
+                ({ wrapper, props: { fetchFlow: fetchFlowMock }, context: { endpoints } } = setup(
+                    {},
+                    true
+                ));
 
                 instance.onChange({ uuid: otherUUID });
                 expect(fetchFlowMock).toHaveBeenCalledTimes(0);

--- a/src/component/__snapshots__/FlowList.test.ts.snap
+++ b/src/component/__snapshots__/FlowList.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`FlowList helpers getFlowOption should return a FlowOption map 1`] = `
 Object {
-  "name": "Colors",
-  "uuid": "a4f64f1b-85bc-477e-b706-de313a022979",
+  "name": "Boring",
+  "uuid": "boring",
 }
 `;
 
@@ -56,21 +56,6 @@ exports[`FlowList render should render select control 1`] = `
     options={
       Array [
         Object {
-          "name": "Colors",
-          "type": "flow",
-          "uuid": "a4f64f1b-85bc-477e-b706-de313a022979",
-        },
-        Object {
-          "name": "Customer Service",
-          "type": "flow",
-          "uuid": "9ecc8e84-6b83-442b-a04a-8094d5de997b",
-        },
-        Object {
-          "name": "JAWS",
-          "type": "flow",
-          "uuid": "c4ad4218-4bca-4261-a41e-51fdef90595d",
-        },
-        Object {
           "name": "Boring",
           "type": "flow",
           "uuid": "boring",
@@ -89,8 +74,8 @@ exports[`FlowList render should render select control 1`] = `
     trimFilter={true}
     value={
       Object {
-        "name": "Colors",
-        "uuid": "a4f64f1b-85bc-477e-b706-de313a022979",
+        "name": "Boring",
+        "uuid": "boring",
       }
     }
     valueComponent={[Function]}

--- a/src/component/actions/Action/Action.test.ts
+++ b/src/component/actions/Action/Action.test.ts
@@ -9,16 +9,48 @@ import {
     actionInteractiveDivSpecId,
     actionBodySpecId
 } from './Action';
+import { FlowNode, SendMsg, StartFlow, SwitchRouter } from '../../../flowTypes';
 
-const config = require('../../../../assets/config');
-const colorsFlowResp = require('../../../../assets/flows/a4f64f1b-85bc-477e-b706-de313a022979.json');
+const config = require('../../../../__test__/assets/config');
 
-const {
-    results: [{ definition: { nodes: [sendMsgNode, , , sendMsgNode1, , , startFlowNode] } }]
-} = colorsFlowResp;
-const { actions: [sendMsgAction] } = sendMsgNode;
-const { actions: [sendMsgAction1] } = sendMsgNode1;
-const { actions: [startFlowAction] } = startFlowNode;
+const sendMsgAction: SendMsg = {
+    uuid: 'send_msg_action0',
+    type: 'send_msg',
+    text: 'Hello World!'
+};
+
+const sendMsgAction1: SendMsg = {
+    uuid: 'send_msg_action1',
+    type: 'send_msg',
+    text: 'Hello World!'
+};
+
+const sendMsgNode: FlowNode = {
+    uuid: 'send_msg_node',
+    actions: [sendMsgAction],
+    exits: []
+};
+
+const startFlowAction: StartFlow = {
+    uuid: 'start_flow_action',
+    type: 'start_flow',
+    flow_name: 'Flow to Start',
+    flow_uuid: 'flow_to_start'
+};
+
+const startFlowNode: FlowNode = {
+    uuid: 'start_flow_node',
+    actions: [startFlowAction],
+    exits: [],
+    router: {
+        type: 'switch',
+        operand: '@child'
+    } as SwitchRouter,
+    wait: {
+        type: 'flow',
+        flow_uuid: 'flow_to_start'
+    }
+};
 
 const context = {
     languages: config.languages
@@ -29,7 +61,7 @@ const spanish = getLanguage(config.languages, 'spa');
 
 const baseProps = {
     thisNodeDragging: false,
-    localization: colorsFlowResp.results[0].definition.localization,
+    localization: { spa: {} },
     first: true,
     action: sendMsgAction,
     render: jest.fn(),
@@ -202,11 +234,7 @@ describe(`${COMPONENT_TO_TEST}`, () => {
 
         describe('getAction', () => {
             it('should return the action passed via props if not localized', () => {
-                const { wrapper, props: { action }, instance } = setup(
-                    { node: sendMsgAction1 },
-                    true
-                );
-
+                const { wrapper, props: { action }, instance } = setup({ node: sendMsgNode }, true);
                 expect(instance.getAction()).toEqual(action);
             });
 

--- a/src/component/actions/Action/__snapshots__/Action.test.ts.snap
+++ b/src/component/actions/Action/__snapshots__/Action.test.ts.snap
@@ -4,7 +4,7 @@ exports[`ActionWrapper render should display hybrid style 1`] = `
 <div
   className="action has_router"
   data-spec="action-container"
-  id="action-64378fc1-19e4-4c8a-be27-aee49ebc728a"
+  id="action-send_msg_action0"
 >
   <div
     className="overlay"
@@ -35,7 +35,7 @@ exports[`ActionWrapper render should display missing_localization style 1`] = `
 <div
   className="action translating missing_localization"
   data-spec="action-container"
-  id="action-cd19e588-3383-4d54-b5df-8dbbc2b0d297"
+  id="action-send_msg_action1"
 >
   <div
     className="overlay"
@@ -66,7 +66,7 @@ exports[`ActionWrapper render should display not_localizable style 1`] = `
 <div
   className="action translating not_localizable"
   data-spec="action-container"
-  id="action-dbcccd07-9966-460a-9fcd-4db5a2f921ab"
+  id="action-start_flow_action"
 >
   <div
     className="overlay"
@@ -97,7 +97,7 @@ exports[`ActionWrapper render should display translating style 1`] = `
 <div
   className="action translating missing_localization"
   data-spec="action-container"
-  id="action-64378fc1-19e4-4c8a-be27-aee49ebc728a"
+  id="action-send_msg_action0"
 >
   <div
     className="overlay"
@@ -128,7 +128,7 @@ exports[`ActionWrapper render should render self, children with base props 1`] =
 <div
   className="action"
   data-spec="action-container"
-  id="action-64378fc1-19e4-4c8a-be27-aee49ebc728a"
+  id="action-send_msg_action0"
 >
   <div
     className="overlay"
@@ -159,7 +159,7 @@ exports[`ActionWrapper render should show move icon 1`] = `
 <div
   className="action"
   data-spec="action-container"
-  id="action-64378fc1-19e4-4c8a-be27-aee49ebc728a"
+  id="action-send_msg_action0"
 >
   <div
     className="overlay"

--- a/src/component/index.test.ts
+++ b/src/component/index.test.ts
@@ -3,11 +3,9 @@ import { FlowEditorConfig } from '../flowTypes';
 import { createSetup, getSpecWrapper, Resp } from '../testUtils';
 import { getBaseLanguage, getLanguage } from '../utils';
 
-const config = require('../../assets/config') as FlowEditorConfig;
-const colorsFlowResp = require('../../assets/flows/a4f64f1b-85bc-477e-b706-de313a022979.json') as Resp;
+const config = require('../../__test__/assets/config') as FlowEditorConfig;
 
 const context = {
-    assetHost: config.assetHost,
     endpoints: config.endpoints,
     languages: config.languages,
     flow: config.flow
@@ -27,6 +25,7 @@ const baseProps = {
 const setup = createSetup<FlowEditorStoreProps>(FlowEditor, baseProps, config);
 
 describe('Root', () => {
+    const definition = require('../../__test__/flows/boring.json');
     describe('render', () => {
         it('should render self, children with required props', () => {
             const { wrapper } = setup({}, true);
@@ -52,7 +51,7 @@ describe('Root', () => {
             const { wrapper } = setup(
                 {
                     language: getLanguage(config.languages, 'eng'),
-                    definition: colorsFlowResp.results[0].definition
+                    definition
                 },
                 true
             );

--- a/src/component/routers/GroupsRouter.test.tsx
+++ b/src/component/routers/GroupsRouter.test.tsx
@@ -1,17 +1,62 @@
 import * as React from 'react';
 import { ConfigProviderContext } from '../../config/ConfigProvider';
-import { FlowDefinition, FlowEditorConfig, SwitchRouter } from '../../flowTypes';
+import { FlowDefinition, FlowEditorConfig, SwitchRouter, FlowNode, SendMsg } from '../../flowTypes';
 import { createSetup, Resp } from '../../testUtils';
 import { GROUP_NOT_FOUND, GROUP_PLACEHOLDER } from '../form/GroupsElement';
 import { GROUP_LABEL } from './constants';
 import { extractGroups, GroupsRouter, GroupsRouterProps, hasGroupsRouter } from './GroupsRouter';
 
-const config = require('../../../assets/config') as FlowEditorConfig;
-const colorsFlowResp = require('../../../assets/flows/a4f64f1b-85bc-477e-b706-de313a022979.json') as Resp;
-const groupsResp = require('../../../assets/groups.json') as Resp;
+const config = require('../../../__test__/assets/config') as FlowEditorConfig;
 
-const definition = colorsFlowResp.results[0].definition as FlowDefinition;
-const { nodes: [sendMsgNode, , , , , groupsRouterNode] } = definition;
+const sendMsgNode: FlowNode = {
+    uuid: 'send_msg_node',
+    actions: [{ type: 'send_msg', text: 'Hello World!' } as SendMsg],
+    exits: []
+};
+
+const groupsRouterNode: FlowNode = {
+    uuid: 'group_router_node',
+    actions: [],
+    router: {
+        type: 'switch',
+        default_exit_uuid: 'exit2',
+        cases: [
+            {
+                uuid: 'case0',
+                type: 'has_group',
+                exit_uuid: 'exit0',
+                arguments: ['group0']
+            },
+            {
+                uuid: 'case1',
+                type: 'has_group',
+                exit_uuid: 'exit1',
+                arguments: ['group1']
+            }
+        ],
+        operand: '@contact.groups'
+    } as SwitchRouter,
+    exits: [
+        {
+            name: 'Early Adopters',
+            uuid: 'exit0',
+            destination_node_uuid: null
+        },
+        {
+            name: 'Subscribers',
+            uuid: 'exit1',
+            destination_node_uuid: null
+        },
+        {
+            uuid: 'exit2',
+            name: 'Other',
+            destination_node_uuid: null
+        }
+    ],
+    wait: {
+        type: 'group'
+    }
+};
 
 const context = {
     endpoints: config.endpoints

--- a/src/component/routers/__snapshots__/GroupsRouter.test.tsx.snap
+++ b/src/component/routers/__snapshots__/GroupsRouter.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`GroupsRouter helpers extractGroups should extract groups from the exits of a groupsRouter node 1`] = `
 Object {
-  "id": "cdbf9e01-aaa7-4381-8259-ee042447bcac",
+  "id": "group0",
   "name": "Early Adopters",
 }
 `;
 
 exports[`GroupsRouter helpers extractGroups should extract groups from the exits of a groupsRouter node 2`] = `
 Object {
-  "id": "33b28bac-b588-43e4-90de-fda77aeaf7c0",
+  "id": "group1",
   "name": "Subscribers",
 }
 `;

--- a/src/external/index.test.ts
+++ b/src/external/index.test.ts
@@ -2,22 +2,21 @@ import { getFlow, getFlows } from '.';
 import { FlowEditorConfig } from '../flowTypes';
 import { Resp } from '../testUtils';
 
-const colorsFlowResp = require('../../assets/flows/a4f64f1b-85bc-477e-b706-de313a022979.json') as Resp;
-const flowsResp = require('../../assets/flows.json') as Resp;
-const { endpoints: { flows: flowsEndpoint } } = require('../../assets/config') as FlowEditorConfig;
+const flowsResp = require('../../__test__/assets/flows.json') as Resp;
+const {
+    endpoints: { flows: flowsEndpoint }
+} = require('../../__test__/assets/config') as FlowEditorConfig;
 
 describe('external', () => {
     describe('getFlow', () => {
         it('should get a flow', async () => {
-            expect(await getFlow(flowsEndpoint, colorsFlowResp.results[0].uuid, false)).toEqual(
-                colorsFlowResp.results[0]
-            );
+            expect(await getFlow('/assets/flows.json', 'boring', false)).toBeDefined();
         });
     });
 
     describe('getFlows', () => {
         it('should fetch a list of flows', async () => {
-            expect(await getFlows(flowsEndpoint)).toEqual(flowsResp.results);
+            expect(await getFlows('/assets/flows.json')).toEqual(flowsResp.results);
         });
     });
 });

--- a/src/store/__snapshots__/thunks.test.ts.snap
+++ b/src/store/__snapshots__/thunks.test.ts.snap
@@ -1,6 +1,214 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Boring Flow nodes removal should remove node node0: Remove node0 1`] = `
+exports[`Flow Manipulation init should initalize definition: fields 1`] = `
+Array [
+  Object {
+    "label": "Unknown Field",
+    "value": "unknown_field",
+  },
+]
+`;
+
+exports[`Flow Manipulation init should initalize definition: groups 1`] = `
+Array [
+  Object {
+    "label": "Flow Participants",
+    "value": "group_0",
+  },
+  Object {
+    "label": "Nonresponsive",
+    "value": "group_1",
+  },
+]
+`;
+
+exports[`Flow Manipulation init should initalize definition: nodes 1`] = `
+Object {
+  "node0": Object {
+    "inboundConnections": Object {},
+    "node": Object {
+      "actions": Array [
+        Object {
+          "text": "Hi there, this is your first action!",
+          "type": "send_msg",
+          "uuid": "node0_action0",
+        },
+        Object {
+          "groups": Array [
+            Object {
+              "name": "Flow Participants",
+              "uuid": "group_0",
+            },
+          ],
+          "type": "add_contact_groups",
+          "uuid": "node0_action1",
+        },
+        Object {
+          "groups": Array [
+            Object {
+              "name": "Nonresponsive",
+              "uuid": "group_1",
+            },
+          ],
+          "type": "remove_contact_groups",
+          "uuid": "node0_action2",
+        },
+      ],
+      "exits": Array [
+        Object {
+          "destination_node_uuid": "node1",
+          "name": null,
+          "uuid": "node0_exit0",
+        },
+      ],
+      "uuid": "node0",
+    },
+    "ui": Object {
+      "position": Object {
+        "bottom": 254,
+        "left": 0,
+        "right": 220,
+        "top": 0,
+      },
+    },
+  },
+  "node1": Object {
+    "inboundConnections": Object {
+      "node0_exit0": "node0",
+    },
+    "node": Object {
+      "actions": Array [],
+      "exits": Array [
+        Object {
+          "destination_node_uuid": "node2",
+          "name": "Red",
+          "uuid": "node1_exit0",
+        },
+        Object {
+          "destination_node_uuid": "node2",
+          "name": "Green",
+          "uuid": "node1_exit1",
+        },
+        Object {
+          "destination_node_uuid": "node2",
+          "name": "Other",
+          "uuid": "node1_exit2",
+        },
+      ],
+      "router": Object {
+        "cases": Array [
+          Object {
+            "arguments": Array [
+              "red",
+            ],
+            "exit_uuid": "uuid_node1_exit0",
+            "type": "has_any_word",
+            "uuid": "node1_case0",
+          },
+          Object {
+            "arguments": Array [
+              "green",
+            ],
+            "exit_uuid": "uuid_node1_exit1",
+            "type": "has_any_word",
+            "uuid": "node1_case1",
+          },
+        ],
+        "default_exit_uuid": "node1_exit2",
+        "operand": "@input",
+        "result_name": "color",
+        "type": "switch",
+      },
+      "uuid": "node1",
+      "wait": Object {
+        "type": "msg",
+      },
+    },
+    "ui": Object {
+      "position": Object {
+        "bottom": 370,
+        "left": 0,
+        "right": 220,
+        "top": 280,
+      },
+      "type": "wait_for_response",
+    },
+  },
+  "node2": Object {
+    "inboundConnections": Object {
+      "node1_exit0": "node1",
+      "node1_exit1": "node1",
+      "node1_exit2": "node1",
+    },
+    "node": Object {
+      "actions": Array [
+        Object {
+          "text": "This has been really great.",
+          "type": "send_msg",
+          "uuid": "node2_action0",
+        },
+        Object {
+          "field": Object {
+            "key": "unknown_field",
+            "name": "Unknown Field",
+          },
+          "type": "set_contact_field",
+          "uuid": "node2_action1",
+          "value": "Some Value",
+        },
+      ],
+      "exits": Array [
+        Object {
+          "destination_node_uuid": "node3",
+          "name": null,
+          "uuid": "node2_exit0",
+        },
+      ],
+      "uuid": "node2",
+    },
+    "ui": Object {
+      "position": Object {
+        "bottom": 498,
+        "left": 0,
+        "right": 220,
+        "top": 400,
+      },
+    },
+  },
+  "node3": Object {
+    "inboundConnections": Object {
+      "node2_exit0": "node2",
+    },
+    "node": Object {
+      "actions": Array [
+        Object {
+          "text": "Thanks for playing!",
+          "type": "send_msg",
+          "uuid": "node3_action0",
+        },
+      ],
+      "exits": Array [
+        Object {
+          "destination_node_uuid": null,
+          "name": null,
+          "uuid": "node3_exit0",
+        },
+      ],
+      "uuid": "node3",
+    },
+    "ui": Object {
+      "position": Object {
+        "bottom": 598,
+        "left": 0,
+        "right": 220,
+        "top": 520,
+      },
+    },
+  },
+}
+`;
+
+exports[`Flow Manipulation nodes removal should remove node node0: Remove node0 1`] = `
 Object {
   "node1": Object {
     "inboundConnections": Object {},
@@ -136,7 +344,7 @@ Object {
 }
 `;
 
-exports[`Boring Flow nodes removal should remove node node1: Remove node1 1`] = `
+exports[`Flow Manipulation nodes removal should remove node node1: Remove node1 1`] = `
 Object {
   "node0": Object {
     "inboundConnections": Object {},
@@ -256,7 +464,7 @@ Object {
 }
 `;
 
-exports[`Boring Flow nodes removal should remove node node2: Remove node2 1`] = `
+exports[`Flow Manipulation nodes removal should remove node node2: Remove node2 1`] = `
 Object {
   "node0": Object {
     "inboundConnections": Object {},
@@ -403,7 +611,7 @@ Object {
 }
 `;
 
-exports[`Boring Flow nodes removal should remove node node3: Remove node3 1`] = `
+exports[`Flow Manipulation nodes removal should remove node node3: Remove node3 1`] = `
 Object {
   "node0": Object {
     "inboundConnections": Object {},
@@ -553,394 +761,6 @@ Object {
         "left": 0,
         "right": 220,
         "top": 400,
-      },
-    },
-  },
-}
-`;
-
-exports[`Color Flow should initalize definition 1`] = `
-Object {
-  "059a8daa-0697-44a6-9486-2386cc417e9d": Object {
-    "inboundConnections": Object {
-      "6f78b6f2-e8a4-4fa0-9277-3e60d9bf2dbf": "e2ecc8de-9774-4b74-a0dc-ca8aea123227",
-      "7571ef74-35b3-4090-ac7a-c4531a500806": "882f8022-7256-4b1c-abf3-7b180f5e7e24",
-    },
-    "node": Object {
-      "actions": Array [
-        Object {
-          "flow_name": "Customer Service",
-          "flow_uuid": "9ecc8e84-6b83-442b-a04a-8094d5de997b",
-          "type": "start_flow",
-          "uuid": "dbcccd07-9966-460a-9fcd-4db5a2f921ab",
-        },
-      ],
-      "exits": Array [
-        Object {
-          "destination_node_uuid": null,
-          "name": "Complete",
-          "uuid": "8c867b8f-f311-4b02-b36b-3688964bdc69",
-        },
-        Object {
-          "destination_node_uuid": null,
-          "name": "Expired",
-          "uuid": "1a81edc4-5f8c-4115-92ef-834dac61c2e7",
-        },
-      ],
-      "router": Object {
-        "cases": Array [
-          Object {
-            "arguments": Array [
-              "C",
-            ],
-            "exit_uuid": "8c867b8f-f311-4b02-b36b-3688964bdc69",
-            "type": "has_run_status",
-            "uuid": "2d247ecc-1d5d-4381-914a-3195b1888f04",
-          },
-          Object {
-            "arguments": Array [
-              "E",
-            ],
-            "exit_uuid": "1a81edc4-5f8c-4115-92ef-834dac61c2e7",
-            "type": "has_run_status",
-            "uuid": "b46ffd80-1b85-44bf-b3f2-01550d4ff302",
-          },
-        ],
-        "default_exit_uuid": null,
-        "operand": "@child",
-        "type": "switch",
-      },
-      "uuid": "059a8daa-0697-44a6-9486-2386cc417e9d",
-      "wait": Object {
-        "flow_uuid": "9ecc8e84-6b83-442b-a04a-8094d5de997b",
-        "type": "flow",
-      },
-    },
-    "ui": Object {
-      "position": Object {
-        "left": 300,
-        "top": 520,
-      },
-      "type": "subflow",
-    },
-  },
-  "46e8d603-8e5d-4435-97dd-1333291aafca": Object {
-    "inboundConnections": Object {
-      "445fc64c-2a18-47cc-89d0-15172826bfcc": "4fac7935-d13b-4b36-bf15-98075dca822a",
-    },
-    "node": Object {
-      "actions": Array [],
-      "exits": Array [
-        Object {
-          "destination_node_uuid": "bc978e00-2f3d-41f2-87c1-26b3f14e5925",
-          "name": "Red",
-          "uuid": "55855afc-f612-4ef9-9288-dcb1dd136052",
-        },
-        Object {
-          "destination_node_uuid": "bc978e00-2f3d-41f2-87c1-26b3f14e5925",
-          "name": "Orange",
-          "uuid": "668ca2ab-8d49-47f5-82a1-e3a82a58e5fb",
-        },
-        Object {
-          "destination_node_uuid": "bc978e00-2f3d-41f2-87c1-26b3f14e5925",
-          "name": "Yellow",
-          "uuid": "14806949-d583-49e2-aa55-03aa16ee5a3a",
-        },
-        Object {
-          "destination_node_uuid": "bc978e00-2f3d-41f2-87c1-26b3f14e5925",
-          "name": "Green",
-          "uuid": "77394377-f6b8-4366-9bef-d468621258ef",
-        },
-        Object {
-          "destination_node_uuid": "bc978e00-2f3d-41f2-87c1-26b3f14e5925",
-          "name": "Blue",
-          "uuid": "92d429d8-c275-4306-9360-93f4b9c7acb1",
-        },
-        Object {
-          "destination_node_uuid": "bc978e00-2f3d-41f2-87c1-26b3f14e5925",
-          "name": "Indigo",
-          "uuid": "2de9af80-1bd9-4f37-839f-073edbd14369",
-        },
-        Object {
-          "destination_node_uuid": "bc978e00-2f3d-41f2-87c1-26b3f14e5925",
-          "name": "Violet",
-          "uuid": "5760ec2f-04d4-492b-817b-9f395633ec79",
-        },
-        Object {
-          "destination_node_uuid": "4fac7935-d13b-4b36-bf15-98075dca822a",
-          "name": "Other",
-          "uuid": "326a41b7-9bce-453b-8783-1113f649663c",
-        },
-      ],
-      "router": Object {
-        "cases": Array [
-          Object {
-            "arguments": Array [
-              "red, r",
-            ],
-            "exit_uuid": "55855afc-f612-4ef9-9288-dcb1dd136052",
-            "type": "has_any_word",
-            "uuid": "fa0a9b24-5f19-4b8e-b287-27af5811de1d",
-          },
-          Object {
-            "arguments": Array [
-              "orange, o",
-            ],
-            "exit_uuid": "668ca2ab-8d49-47f5-82a1-e3a82a58e5fb",
-            "type": "has_any_word",
-            "uuid": "b5f900b9-ad13-479a-8ad3-1f1ad5ac88f2",
-          },
-          Object {
-            "arguments": Array [
-              "yellow, y",
-            ],
-            "exit_uuid": "14806949-d583-49e2-aa55-03aa16ee5a3a",
-            "type": "has_any_word",
-            "uuid": "e9c842e8-f1c5-4f07-97e7-50a4f93b22e5",
-          },
-          Object {
-            "arguments": Array [
-              "green, g",
-            ],
-            "exit_uuid": "77394377-f6b8-4366-9bef-d468621258ef",
-            "type": "has_any_word",
-            "uuid": "cc5894af-5dce-454e-a525-3d7c5c41d21d",
-          },
-          Object {
-            "arguments": Array [
-              "blue, b",
-            ],
-            "exit_uuid": "92d429d8-c275-4306-9360-93f4b9c7acb1",
-            "type": "has_any_word",
-            "uuid": "590d13e3-7b47-44e3-b8a0-ba9bd41d75d2",
-          },
-          Object {
-            "arguments": Array [
-              "indigo, i",
-            ],
-            "exit_uuid": "2de9af80-1bd9-4f37-839f-073edbd14369",
-            "type": "has_any_word",
-            "uuid": "2a7cbed1-6597-4545-b145-14a2e9282e6c",
-          },
-          Object {
-            "arguments": Array [
-              "violet, v",
-            ],
-            "exit_uuid": "5760ec2f-04d4-492b-817b-9f395633ec79",
-            "type": "has_any_word",
-            "uuid": "ab99e18c-433f-436e-9278-08bcf506f433",
-          },
-        ],
-        "default_exit_uuid": "326a41b7-9bce-453b-8783-1113f649663c",
-        "operand": "@input",
-        "result_name": "color",
-        "type": "switch",
-      },
-      "uuid": "46e8d603-8e5d-4435-97dd-1333291aafca",
-      "wait": Object {
-        "type": "msg",
-      },
-    },
-    "ui": Object {
-      "position": Object {
-        "left": 300,
-        "top": 120,
-      },
-      "type": "wait_for_response",
-    },
-  },
-  "4fac7935-d13b-4b36-bf15-98075dca822a": Object {
-    "inboundConnections": Object {
-      "326a41b7-9bce-453b-8783-1113f649663c": "46e8d603-8e5d-4435-97dd-1333291aafca",
-    },
-    "node": Object {
-      "actions": Array [
-        Object {
-          "text": "What's your favorite color, (r)ed, (o)range, (y)ellow, (g)reen, (b)lue, (i)ndigo or (v)iolet?",
-          "type": "send_msg",
-          "uuid": "64378fc1-19e4-4c8a-be27-aee49ebc728a",
-        },
-      ],
-      "exits": Array [
-        Object {
-          "destination_node_uuid": "46e8d603-8e5d-4435-97dd-1333291aafca",
-          "name": null,
-          "uuid": "445fc64c-2a18-47cc-89d0-15172826bfcc",
-        },
-      ],
-      "uuid": "4fac7935-d13b-4b36-bf15-98075dca822a",
-    },
-    "ui": Object {
-      "position": Object {
-        "left": 0,
-        "top": 0,
-      },
-    },
-  },
-  "533b64e2-5906-4d33-a8e9-64f1cb6c20dd": Object {
-    "inboundConnections": Object {
-      "a8bdc1c5-0283-4656-b932-4f4094f4cc7e": "bc978e00-2f3d-41f2-87c1-26b3f14e5925",
-    },
-    "node": Object {
-      "actions": Array [
-        Object {
-          "text": "Yuck",
-          "type": "send_msg",
-          "uuid": "28b9e295-1102-4f13-bd9d-4a7b11f4fcdc",
-        },
-      ],
-      "exits": Array [
-        Object {
-          "destination_node_uuid": "882f8022-7256-4b1c-abf3-7b180f5e7e24",
-          "name": null,
-          "uuid": "9de30522-db84-4471-bce6-99f6d0a200e0",
-        },
-      ],
-      "uuid": "533b64e2-5906-4d33-a8e9-64f1cb6c20dd",
-    },
-    "ui": Object {
-      "position": Object {
-        "left": 680,
-        "top": 340,
-      },
-    },
-  },
-  "882f8022-7256-4b1c-abf3-7b180f5e7e24": Object {
-    "inboundConnections": Object {
-      "9de30522-db84-4471-bce6-99f6d0a200e0": "533b64e2-5906-4d33-a8e9-64f1cb6c20dd",
-    },
-    "node": Object {
-      "actions": Array [],
-      "exits": Array [
-        Object {
-          "destination_node_uuid": null,
-          "name": "Early Adopters",
-          "uuid": "ae0b5c58-222f-4722-9fd4-faf32dec5f2b",
-        },
-        Object {
-          "destination_node_uuid": "059a8daa-0697-44a6-9486-2386cc417e9d",
-          "name": "Subscribers",
-          "uuid": "7571ef74-35b3-4090-ac7a-c4531a500806",
-        },
-        Object {
-          "destination_node_uuid": null,
-          "name": "Other",
-          "uuid": "0dcd0320-2a3b-4c41-97b3-45e147682cfa",
-        },
-      ],
-      "router": Object {
-        "cases": Array [
-          Object {
-            "arguments": Array [
-              "cdbf9e01-aaa7-4381-8259-ee042447bcac",
-            ],
-            "exit_uuid": "ae0b5c58-222f-4722-9fd4-faf32dec5f2b",
-            "type": "has_group",
-            "uuid": "a2e446bf-7181-40f9-8996-5d2453486218",
-          },
-          Object {
-            "arguments": Array [
-              "33b28bac-b588-43e4-90de-fda77aeaf7c0",
-            ],
-            "exit_uuid": "7571ef74-35b3-4090-ac7a-c4531a500806",
-            "type": "has_group",
-            "uuid": "fa8d0d3a-067e-4460-9cff-0474ecc4e8ca",
-          },
-        ],
-        "default_exit_uuid": "0dcd0320-2a3b-4c41-97b3-45e147682cfa",
-        "operand": "@contact.groups",
-        "type": "switch",
-      },
-      "uuid": "882f8022-7256-4b1c-abf3-7b180f5e7e24",
-      "wait": Object {
-        "type": "group",
-      },
-    },
-    "ui": Object {
-      "position": Object {
-        "left": 640,
-        "top": 460,
-      },
-      "type": "split_by_groups",
-    },
-  },
-  "bc978e00-2f3d-41f2-87c1-26b3f14e5925": Object {
-    "inboundConnections": Object {
-      "14806949-d583-49e2-aa55-03aa16ee5a3a": "46e8d603-8e5d-4435-97dd-1333291aafca",
-      "2de9af80-1bd9-4f37-839f-073edbd14369": "46e8d603-8e5d-4435-97dd-1333291aafca",
-      "55855afc-f612-4ef9-9288-dcb1dd136052": "46e8d603-8e5d-4435-97dd-1333291aafca",
-      "5760ec2f-04d4-492b-817b-9f395633ec79": "46e8d603-8e5d-4435-97dd-1333291aafca",
-      "668ca2ab-8d49-47f5-82a1-e3a82a58e5fb": "46e8d603-8e5d-4435-97dd-1333291aafca",
-      "77394377-f6b8-4366-9bef-d468621258ef": "46e8d603-8e5d-4435-97dd-1333291aafca",
-      "92d429d8-c275-4306-9360-93f4b9c7acb1": "46e8d603-8e5d-4435-97dd-1333291aafca",
-    },
-    "node": Object {
-      "actions": Array [],
-      "exits": Array [
-        Object {
-          "destination_node_uuid": "e2ecc8de-9774-4b74-a0dc-ca8aea123227",
-          "name": "Red",
-          "uuid": "7b245d49-e9e3-4387-b4ad-48deb03528cd",
-        },
-        Object {
-          "destination_node_uuid": "533b64e2-5906-4d33-a8e9-64f1cb6c20dd",
-          "name": "Other",
-          "uuid": "a8bdc1c5-0283-4656-b932-4f4094f4cc7e",
-        },
-      ],
-      "router": Object {
-        "cases": Array [
-          Object {
-            "arguments": Array [
-              "red, r",
-            ],
-            "exit_uuid": "7b245d49-e9e3-4387-b4ad-48deb03528cd",
-            "type": "has_any_word",
-            "uuid": "87173eee-5270-4233-aede-ca88e14b672a",
-          },
-        ],
-        "default_exit_uuid": "a8bdc1c5-0283-4656-b932-4f4094f4cc7e",
-        "operand": "@run.results.color ",
-        "type": "switch",
-      },
-      "uuid": "bc978e00-2f3d-41f2-87c1-26b3f14e5925",
-      "wait": Object {
-        "type": "exp",
-      },
-    },
-    "ui": Object {
-      "position": Object {
-        "left": 440,
-        "top": 240,
-      },
-      "type": "split_by_expression",
-    },
-  },
-  "e2ecc8de-9774-4b74-a0dc-ca8aea123227": Object {
-    "inboundConnections": Object {
-      "7b245d49-e9e3-4387-b4ad-48deb03528cd": "bc978e00-2f3d-41f2-87c1-26b3f14e5925",
-    },
-    "node": Object {
-      "actions": Array [
-        Object {
-          "text": "Mine too!",
-          "type": "send_msg",
-          "uuid": "cd19e588-3383-4d54-b5df-8dbbc2b0d297",
-        },
-      ],
-      "exits": Array [
-        Object {
-          "destination_node_uuid": "059a8daa-0697-44a6-9486-2386cc417e9d",
-          "name": null,
-          "uuid": "6f78b6f2-e8a4-4fa0-9277-3e60d9bf2dbf",
-        },
-      ],
-      "uuid": "e2ecc8de-9774-4b74-a0dc-ca8aea123227",
-    },
-    "ui": Object {
-      "position": Object {
-        "left": 200,
-        "top": 340,
       },
     },
   },

--- a/src/store/flowContext.test.ts
+++ b/src/store/flowContext.test.ts
@@ -20,14 +20,12 @@ import reducer, {
     RenderNodeMap
 } from './flowContext';
 
-const colorsFlow = require('../../assets/flows/a4f64f1b-85bc-477e-b706-de313a022979.json');
-const customerServiceFlow = require('../../assets/flows/9ecc8e84-6b83-442b-a04a-8094d5de997b.json');
 const config = require('../../assets/config');
+const definition = require('../../__test__/flows/boring.json');
 
 describe('flowContext action creators', () => {
     describe('updateDefinition', () => {
         it('should create an action to update definition state', () => {
-            const { results: [{ definition }] } = colorsFlow;
             const expectedAction = {
                 type: Constants.UPDATE_DEFINITION,
                 payload: {
@@ -40,10 +38,7 @@ describe('flowContext action creators', () => {
 
     describe('updateDependencies', () => {
         it('should create an action to update dependencies state', () => {
-            const dependencies = [
-                colorsFlow.results[0].definition,
-                customerServiceFlow.results[0].definition
-            ];
+            const dependencies = [definition];
             const expectedAction = {
                 type: Constants.UPDATE_DEPENDENCIES,
                 payload: {
@@ -56,7 +51,6 @@ describe('flowContext action creators', () => {
 
     describe('updateLocalizations', () => {
         it('should create an action to update localizations state', () => {
-            const { definition } = colorsFlow.results[0];
             const iso = 'spa';
             const localizations = [
                 Localization.translate(
@@ -125,7 +119,6 @@ describe('flowContext reducers', () => {
         });
 
         it('should handle UPDATE_DEFINITION', () => {
-            const { results: [{ definition }] } = colorsFlow;
             const action = updateDefinition(definition);
             expect(reduce(action)).toEqual(definition);
         });
@@ -139,10 +132,7 @@ describe('flowContext reducers', () => {
         });
 
         it('should handle UPDATE_DEPENDENCIES', () => {
-            const dependencies = [
-                colorsFlow.results[0].definition,
-                customerServiceFlow.results[0].definition
-            ];
+            const dependencies = [definition];
             const action = updateDependencies(dependencies);
             expect(reduce(action)).toEqual(dependencies);
         });
@@ -156,7 +146,6 @@ describe('flowContext reducers', () => {
         });
 
         it('should handle UPDATE_LOCALIZATIONS', () => {
-            const { definition } = colorsFlow.results[0];
             const iso = 'spa';
             const localizations = [
                 Localization.translate(

--- a/src/store/flowEditor.test.ts
+++ b/src/store/flowEditor.test.ts
@@ -33,8 +33,8 @@ import { FlowNode } from '../flowTypes';
 import { RenderNode } from './flowContext';
 
 const config = require('../../assets/config');
-const flowsResp = require('../../assets/flows.json');
-const colorsFlow = require('../../assets/flows/a4f64f1b-85bc-477e-b706-de313a022979.json');
+const flowsResp = require('../../__test__/assets/flows.json');
+const definition = require('../../__test__/flows/boring.json');
 
 describe('flowEditor action creators', () => {
     describe('updateTranslating', () => {
@@ -168,7 +168,6 @@ describe('flowEditor action creators', () => {
 
     describe('updateGhostNode', () => {
         it('should create an action to update ghostNode state', () => {
-            const { definition } = colorsFlow.results[0];
             const fromNode: RenderNode = {
                 node: definition.nodes[0],
                 ui: definition._ui.nodes[definition.nodes[0].uuid],
@@ -341,7 +340,6 @@ describe('flowEditor reducers', () => {
         });
 
         it('should handle UPDATE_GHOST_NODE', () => {
-            const { definition } = colorsFlow.results[0];
             const fromNode: RenderNode = {
                 node: definition.nodes[0],
                 ui: definition._ui.nodes[definition.nodes[0].uuid],

--- a/src/store/helpers.test.ts
+++ b/src/store/helpers.test.ts
@@ -5,7 +5,7 @@ import {
     getLocalizations,
     getUniqueDestinations,
     getCollisions,
-    getFlowDetails
+    getFlowComponents
 } from './helpers';
 import { v4 as generateUUID } from 'uuid';
 
@@ -15,20 +15,25 @@ import { AnyAction, SendMsg, Exit, Case, FlowPosition, FlowDefinition } from '..
 describe('helpers', () => {
     const definition: FlowDefinition = require('../../__test__/flows/boring.json');
 
-    describe('getFlowDetails', () => {
+    describe('initializeFlow', () => {
         it('should find groups in definition', () => {
-            const flowDetails = getFlowDetails(definition);
-            expect(flowDetails.groups.length).toBe(2);
+            const flowDetails = getFlowComponents(definition);
+            expect(flowDetails.groups).toEqual([
+                { label: 'Flow Participants', value: 'group_0' },
+                { label: 'Nonresponsive', value: 'group_1' }
+            ]);
         });
 
         it('should find fields in definition', () => {
-            const flowDetails = getFlowDetails(definition);
-            expect(flowDetails.fields.length).toBe(1);
+            const flowDetails = getFlowComponents(definition);
+            expect(flowDetails.fields).toEqual([
+                { label: 'Unknown Field', value: 'unknown_field' }
+            ]);
         });
     });
 
     describe('RenderNodeMap', () => {
-        const nodes = getFlowDetails(definition).renderNodeMap;
+        const nodes = getFlowComponents(definition).renderNodeMap;
 
         it('should suggest response names', () => {
             const suggestison = getSuggestedResultName({

--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -235,7 +235,7 @@ export const getGhostNode = (fromNode: RenderNode, nodes: RenderNodeMap) => {
     return ghostNode;
 };
 
-export interface FlowDetails {
+export interface FlowComponents {
     renderNodeMap: RenderNodeMap;
     groups: SearchResult[];
     fields: SearchResult[];
@@ -248,7 +248,7 @@ export const isGroupAction = (actionType: string) => {
 /**
  * Processes an initial FlowDefinition for details necessary for the editor
  */
-export const getFlowDetails = ({ nodes, _ui }: FlowDefinition): FlowDetails => {
+export const getFlowComponents = ({ nodes, _ui }: FlowDefinition): FlowComponents => {
     const renderNodeMap: RenderNodeMap = {};
 
     // our groups and fields referenced within

--- a/src/store/mutators.test.ts
+++ b/src/store/mutators.test.ts
@@ -15,11 +15,11 @@ import {
 import { RenderNodeMap } from './flowContext';
 import { SendMsg, FlowDefinition, FlowNode } from '../flowTypes';
 import { dump } from '../utils';
-import { getNode, getExitIndex, getActionIndex, getFlowDetails } from './helpers';
+import { getNode, getExitIndex, getActionIndex, getFlowComponents } from './helpers';
 
 describe('mutators', () => {
     const definition: FlowDefinition = require('../../__test__/flows/boring.json');
-    const nodes = getFlowDetails(definition).renderNodeMap;
+    const { renderNodeMap: nodes } = getFlowComponents(definition);
 
     it('should throw for missing nodes', () => {
         expect(() => {

--- a/src/store/nodeEditor.test.ts
+++ b/src/store/nodeEditor.test.ts
@@ -18,7 +18,7 @@ import reducer, {
     actionToEdit as actionToEditReducer
 } from './nodeEditor';
 
-const colorsFlow = require('../../assets/flows/a4f64f1b-85bc-477e-b706-de313a022979.json');
+const definition = require('../../__test__/flows/boring.json');
 
 describe('nodeEditor action creators', () => {
     describe('updateTypeConfig', () => {
@@ -75,7 +75,7 @@ describe('nodeEditor action creators', () => {
 
     describe('updateActionToEdit', () => {
         it('should create an action to update actionToEdit state', () => {
-            const { actions: [actionToEdit] } = colorsFlow.results[0].definition.nodes[0];
+            const { actions: [actionToEdit] } = definition.nodes[0];
             const expectedAction = {
                 type: Constants.UPDATE_ACTION_TO_EDIT,
                 payload: {
@@ -88,7 +88,7 @@ describe('nodeEditor action creators', () => {
 
     describe('updateNodeToEdit', () => {
         it('should create an action to update nodeToEdit state', () => {
-            const nodeToEdit = colorsFlow.results[0].definition.nodes[0];
+            const nodeToEdit = definition.nodes[0];
             const expectedAction = {
                 type: Constants.UPDATE_NODE_TO_EDIT,
                 payload: {
@@ -192,7 +192,7 @@ describe('nodeEditor reducers', () => {
         });
 
         it('should handle UPDATE_NODE_TO_EDIT', () => {
-            const nodeToEdit = colorsFlow.results[0].definition.nodes[0];
+            const nodeToEdit = definition.nodes[0];
             const action = updateNodeToEdit(nodeToEdit);
             expect(reduce(action)).toEqual(nodeToEdit);
         });
@@ -206,7 +206,7 @@ describe('nodeEditor reducers', () => {
         });
 
         it('should handle UPDATE_ACTION_TO_EDIT', () => {
-            const { actions: [actionToEdit] } = colorsFlow.results[0].definition.nodes[0];
+            const { actions: [actionToEdit] } = definition.nodes[0];
             const action = updateActionToEdit(actionToEdit);
             expect(reduce(action)).toEqual(actionToEdit);
         });

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -4,7 +4,7 @@ import { Dispatch } from 'react-redux';
 import { v4 as generateUUID } from 'uuid';
 import { hasCases } from '../component/NodeEditor/NodeEditor';
 import { getTypeConfig } from '../config';
-import { FlowDetails, getFlow, getFlows } from '../external';
+import { getFlow, getFlows, FlowDetails } from '../external';
 import {
     Action,
     AnyAction,
@@ -43,7 +43,8 @@ import {
     getCollision,
     getGhostNode,
     getLocalizations,
-    getFlowDetails
+    getFlowComponents,
+    FlowComponents
 } from './helpers';
 import * as mutators from './mutators';
 import {
@@ -139,13 +140,14 @@ let debounceReflow: any = null;
 export const initializeFlow = (definition: FlowDefinition) => (
     dispatch: DispatchWithState,
     getState: GetState
-): RenderNodeMap => {
-    const { renderNodeMap } = getFlowDetails(definition);
+): FlowComponents => {
+    const flowComponents = getFlowComponents(definition);
+
     // store our flow definition without any nodes
     dispatch(updateDefinition(mutators.pruneDefinition(definition)));
-    dispatch(updateNodes(renderNodeMap));
+    dispatch(updateNodes(flowComponents.renderNodeMap));
     dispatch(updateFetchingFlow(false));
-    return renderNodeMap;
+    return flowComponents;
 };
 
 export const fetchFlow = (endpoint: string, uuid: string) => (

--- a/src/utils/__snapshots__/index.test.tsx.snap
+++ b/src/utils/__snapshots__/index.test.tsx.snap
@@ -51,9 +51,9 @@ LocalizedObject {
   "localized": false,
   "localizedKeys": Object {},
   "localizedObject": Object {
-    "text": "What's your favorite color, (r)ed, (o)range, (y)ellow, (g)reen, (b)lue, (i)ndigo or (v)iolet?",
+    "text": "Hello World!",
     "type": "send_msg",
-    "uuid": "64378fc1-19e4-4c8a-be27-aee49ebc728a",
+    "uuid": "send_msg_action",
   },
 }
 `;
@@ -79,7 +79,7 @@ LocalizedObject {
       "¿Cuál es tu color favorito?",
     ],
     "type": "send_msg",
-    "uuid": "64378fc1-19e4-4c8a-be27-aee49ebc728a",
+    "uuid": "send_msg_action",
   },
 }
 `;
@@ -99,9 +99,9 @@ LocalizedObject {
   "localized": false,
   "localizedKeys": Object {},
   "localizedObject": Object {
-    "text": "What's your favorite color, (r)ed, (o)range, (y)ellow, (g)reen, (b)lue, (i)ndigo or (v)iolet?",
+    "text": "Hello World!",
     "type": "send_msg",
-    "uuid": "64378fc1-19e4-4c8a-be27-aee49ebc728a",
+    "uuid": "send_msg_action",
   },
 }
 `;

--- a/src/utils/index.test.tsx
+++ b/src/utils/index.test.tsx
@@ -20,13 +20,14 @@ import {
     isRealValue
 } from '.';
 import { operatorConfigList } from '../config';
-import { ContactProperties } from '../flowTypes';
+import { ContactProperties, SendMsg } from '../flowTypes';
 
 const config = require('../../assets/config');
-const {
-    results: [{ definition: colorsFlow }]
-} = require('../../assets/flows/a4f64f1b-85bc-477e-b706-de313a022979.json');
-const { nodes: [{ actions: [sendMsgAction] }] } = colorsFlow;
+const sendMsgAction: SendMsg = {
+    uuid: 'send_msg_action',
+    type: 'send_msg',
+    text: 'Hello World!'
+};
 
 describe('utils', () => {
     describe('toBoolMap', () => {
@@ -168,7 +169,12 @@ describe('utils', () => {
         it('should return a localized object', () => {
             ['eng', 'spa', 'fre'].forEach(iso => {
                 expect(
-                    getLocalization(sendMsgAction, colorsFlow.localization, iso, config.languages)
+                    getLocalization(
+                        sendMsgAction,
+                        { spa: { send_msg_action: { text: ['¿Cuál es tu color favorito?'] } } },
+                        iso,
+                        config.languages
+                    )
                 ).toMatchSnapshot();
             });
         });


### PR DESCRIPTION
Removes references to colors and customer service flows for all of the tests in the store module (and any references to non-test assets). Also refactors a few other tests as an example for use to more toward (`Action.test.ts`, `GroupRouter.test.tsx`, etc).