### PR TITLE
Rework package scoping

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
 save-exact=true
-scope=nyaruka
-access=public

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "flow-editor",
+  "name": "@nyaruka/flow-editor",
   "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -11490,12 +11490,6 @@
       "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
       "dev": true
     },
-    "lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-      "dev": true
-    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -12122,15 +12116,6 @@
       "dev": true,
       "requires": {
         "lower-case": "1.1.4"
-      }
-    },
-    "node-emoji": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
-      "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
-      "dev": true,
-      "requires": {
-        "lodash.toarray": "4.4.0"
       }
     },
     "node-fetch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nyaruka/flow-editor",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,9 @@
     "tag": "git push — tags origin master",
     "preversion": "npm run test:local",
     "version": "npm run build:umd",
-    "postversion": "npm run tag",
-    "precommit": "lint-staged"
+    "postversion": "npm run tag && npm run release",
+    "precommit": "lint-staged",
+    "release": "npm publish --access public"
   },
   "lint-staged": {
     "*.{ts,tsx,js,css,md}": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@nyaruka/flow-editor",
   "license": "AGPL-3.0",
   "repository": "git://github.com/nyaruka/floweditor.git",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "'Standalone flow editing tool designed for use within the RapidPro suite of messaging tools but can be adopted for use outside of that ecosystem.'",
   "browser": "umd/flow-editor.min.js",
   "unpkg": "umd/flow-editor.min.js",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
-  "name": "flow-editor",
+  "name": "@nyaruka/flow-editor",
   "license": "AGPL-3.0",
   "repository": "git://github.com/nyaruka/floweditor.git",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "'Standalone flow editing tool designed for use within the RapidPro suite of messaging tools but can be adopted for use outside of that ecosystem.'",
   "browser": "umd/flow-editor.min.js",
+  "unpkg": "umd/flow-editor.min.js",
   "author": "Nyaruka <code@nyaruka.com>",
-  "files": ["umd"],
+  "files": [
+    "umd"
+  ],
   "scripts": {
     "test": "jest --maxWorkers=4 --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "test:local": "jest",
@@ -35,8 +38,8 @@
     "lambda:serve": "netlify-lambda serve lambda-src",
     "lambda:build": "netlify-lambda build lambda-src",
     "tag": "git push — tags origin master",
-    "preversion": "npm run lint:ts && npm run test:local",
-    "version": "npm run build:amd",
+    "preversion": "npm run test:local",
+    "version": "npm run build:umd",
     "postversion": "npm run tag",
     "precommit": "lint-staged"
   },

--- a/webpack/webpack.umd.js
+++ b/webpack/webpack.umd.js
@@ -5,27 +5,29 @@ const paths = require('./paths');
 const { uglifyPlugin, compressionPlugin } = require('./plugins');
 const { typingsForCssModulesLoader, postCSSLoader, awesomeTypeScriptLoader } = require('./loaders');
 const commonConfig = require('./webpack.common');
+
 const pascalCase = str => require('camelcase')(str, { pascalCase: true });
-const pkg = require('../package.json');
+
+const pkgName = require('../package.json').name.replace('@nyaruka/', '');
 
 const prodConfig = {
     entry: {
-        [pkg.name]: paths.lib,
-        [`${pkg.name}.min`]: paths.lib
+        [pkgName]: paths.lib,
+        [`${pkgName}.min`]: paths.lib
     },
     output: {
         path: paths.umd,
         filename: '[name].js',
         libraryTarget: 'umd',
         libraryExport: 'default',
-        library: pascalCase(pkg.name),
+        library: pascalCase(pkgName),
         umdNamedDefine: true
     },
     plugins: [
         new EnvironmentPlugin({
             NODE_ENV: 'production'
         }),
-        new ExtractTextPlugin(`${pkg.name}.min.css`),
+        new ExtractTextPlugin(`${pkgName}.min.css`),
         new ModuleConcatenationPlugin(),
         uglifyPlugin,
         compressionPlugin


### PR DESCRIPTION
This PR ensures we're doing the right thing by unpkg (as a scoped package) when building the `umd` distribution folder. These changes were used to publish the [latest version of the package](https://unpkg.com/@nyaruka/flow-editor@1.1.2/). Running the `npm version patch` command bumped us two patch versions for some reason 🤷‍♂️. I'll look into a publishing tool/process so that we can prevent that sort of thing from happening in the future. 