### PR TITLE
Fix footer style

### DIFF
--- a/src/component/Modal.scss
+++ b/src/component/Modal.scss
@@ -36,6 +36,7 @@
 }
 
 .footer {
+    display: flex;
     background: #f1f1f1;
     padding: 12px;
     height: 45px;


### PR DESCRIPTION
Modal footer needs `display: flex;` to keep buttons vertically centered when timeout control isn't present.