### PR TITLE
Apply isOptionUnique callback to GroupsElement

### DIFF
--- a/src/component/form/AttribElement.test.tsx
+++ b/src/component/form/AttribElement.test.tsx
@@ -1,18 +1,7 @@
-import { ResultType } from '../../flowTypes';
-import { composeComponentTestUtils } from '../../testUtils';
-import { configProviderContext } from '../../testUtils';
-import { getSelectClass, V4_UUID, setTrue, set } from '../../utils';
-import AttribElement, {
-    AttribElementProps,
-    attribExists,
-    CREATE_PROMPT,
-    createNewOption,
-    isOptionUnique,
-    isValidNewOption,
-    NOT_FOUND,
-    PLACEHOLDER
-} from './AttribElement';
 import { Asset, AssetType } from '../../services/AssetService';
+import { composeComponentTestUtils, configProviderContext } from '../../testUtils';
+import { isOptionUnique, isValidNewOption, set, setTrue } from '../../utils';
+import AttribElement, { AttribElementProps, CREATE_PROMPT, createNewOption } from './AttribElement';
 
 const initial: Asset = {
     id: 'name',
@@ -30,63 +19,6 @@ const { setup, spyOn } = composeComponentTestUtils(AttribElement, baseProps);
 
 describe(AttribElement.name, () => {
     describe('helpers', () => {
-        describe('attribExists', () => {
-            const matchingOptions = [
-                {
-                    name: 'Expected Delivery Date',
-                    id: 'expected_delivery_date',
-                    type: 'field'
-                }
-            ];
-
-            it('should return true if field exists in matching options provided by react-select', () => {
-                expect(attribExists('expected delivery date', matchingOptions)).toBeTruthy();
-            });
-
-            it('should return false if field does not exist in matching options provided by react-select', () => {
-                expect(attribExists('national id', [])).toBeFalsy();
-                expect(attribExists('national id', matchingOptions)).toBeFalsy();
-            });
-        });
-
-        describe('isOptionUnique', () => {
-            const isOptionUniqueSignature = {
-                labelKey: 'name',
-                valueKey: 'id',
-                options: []
-            };
-
-            it('should return true if new option is unique', () => {
-                const newOption = {
-                    id: '2e020526-06a7-4acc-8f3f-90b4ceffdd91',
-                    name: 'Age',
-                    type: AssetType.Field
-                };
-
-                expect(
-                    isOptionUnique({
-                        ...isOptionUniqueSignature,
-                        option: newOption
-                    })
-                ).toBeTruthy();
-            });
-
-            it('should return false if new option is not unique', () => {
-                const newOption = {
-                    id: 'name',
-                    name: 'Name',
-                    type: AssetType.Property
-                };
-
-                expect(
-                    isOptionUnique({
-                        ...isOptionUniqueSignature,
-                        option: newOption
-                    })
-                ).toBeFalsy();
-            });
-        });
-
         describe('createNewOption', () => {
             it('should return a new SearchResult', () => {
                 const newOption = { label: 'Home Phone', labelKey: 'name', valueKey: 'id' };

--- a/src/component/form/AttribElement.tsx
+++ b/src/component/form/AttribElement.tsx
@@ -1,19 +1,12 @@
 import * as isEqual from 'fast-deep-equal';
 import * as React from 'react';
-import { connect } from 'react-redux';
-import {
-    IsOptionUniqueHandler,
-    IsValidNewOptionHandler,
-    NewOptionCreatorHandler
-} from 'react-select';
-import { v4 as generateUUID } from 'uuid';
+import { NewOptionCreatorHandler } from 'react-select';
+
 import { CreateOptions, ResultType } from '../../flowTypes';
-import { AppState, DispatchWithState } from '../../store';
-import { getSelectClass, isValidLabel, propertyExists, dump, snakify } from '../../utils';
+import { Asset, Assets, AssetType } from '../../services/AssetService';
+import { getSelectClass, isOptionUnique, isValidNewOption, snakify } from '../../utils';
 import SelectSearch from '../SelectSearch';
 import FormElement, { FormElementProps } from './FormElement';
-import { bindActionCreators } from 'redux';
-import { Asset, AssetType, Assets } from '../../services/AssetService';
 
 export interface AttribElementProps extends FormElementProps {
     initial: Asset;
@@ -32,16 +25,6 @@ interface AttribElementState {
 export const PLACEHOLDER = 'Enter the name of an existing attribute or create a new one';
 export const NOT_FOUND = 'Invalid attribute name';
 export const CREATE_PROMPT = 'New attribute: ';
-
-export const attribExists = (newOptName: string, options: any[]) =>
-    options.find(({ name }) => name.toLowerCase().trim() === newOptName.toLowerCase().trim())
-        ? true
-        : false;
-
-export const isValidNewOption: IsValidNewOptionHandler = ({ label }) => isValidLabel(label);
-
-export const isOptionUnique: IsOptionUniqueHandler = ({ option, options, labelKey, valueKey }) =>
-    !propertyExists(option.name) && !attribExists(option.name, options);
 
 export const createNewOption: NewOptionCreatorHandler = ({ label }) => ({
     id: snakify(label),

--- a/src/component/form/GroupsElement.test.ts
+++ b/src/component/form/GroupsElement.test.ts
@@ -8,7 +8,6 @@ import GroupsElement, {
     GROUP_PLACEHOLDER,
     GROUP_PROMPT,
     GroupsElementProps,
-    isValidNewOption
 } from './GroupsElement';
 import AssetService from '../../services/AssetService';
 
@@ -23,18 +22,6 @@ const { setup, spyOn } = composeComponentTestUtils(GroupsElement, baseProps);
 
 describe(GroupsElement.name, () => {
     describe('helpers', () => {
-        describe('isValidNewOption', () => {
-            it('should return false if new option is invalid', () => {
-                expect(isValidNewOption({ label: '$$$' })).toBeFalsy();
-            });
-
-            it('should return true if new option is valid', () => {
-                const newGroup = { label: 'new group' };
-
-                expect(isValidNewOption(newGroup)).toBeTruthy();
-            });
-        });
-
         describe('createNewOption', () => {
             it('should generate a new search result object', () => {
                 const newGroup = createSelectOption({ label: 'Friends' });

--- a/src/component/form/GroupsElement.tsx
+++ b/src/component/form/GroupsElement.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
+import { NewOptionCreatorHandler } from 'react-select';
 import { v4 as generateUUID } from 'uuid';
+
 import { ResultType } from '../../flowTypes';
-import { getSelectClass, isValidLabel, jsonEqual } from '../../utils';
+import { Asset, Assets, AssetType } from '../../services/AssetService';
+import { getSelectClass, isValidNewOption, jsonEqual, isOptionUnique } from '../../utils';
 import SelectSearch from '../SelectSearch';
 import FormElement, { FormElementProps } from './FormElement';
-import { NewOptionCreatorHandler, IsValidNewOptionHandler } from 'react-select';
-import { Assets, Asset, AssetType } from '../../services/AssetService';
 
 export interface GroupOption {
     group: string;
@@ -25,9 +26,6 @@ interface GroupsElementState {
     groups: Asset[];
     errors: string[];
 }
-
-export const isValidNewOption: IsValidNewOptionHandler = ({ label }) =>
-    !label ? false : isValidLabel(label);
 
 export const createNewOption: NewOptionCreatorHandler = ({ label }): Asset => ({
     id: generateUUID(),
@@ -99,6 +97,7 @@ export default class GroupsElement extends React.Component<GroupsElementProps, G
 
         if (this.props.add) {
             createOptions.isValidNewOption = isValidNewOption;
+            createOptions.isOptionUnique = isOptionUnique;
             createOptions.createNewOption = createNewOption;
             createOptions.createPrompt = GROUP_PROMPT;
         }

--- a/src/component/form/__snapshots__/GroupsElement.test.ts.snap
+++ b/src/component/form/__snapshots__/GroupsElement.test.ts.snap
@@ -19,6 +19,7 @@ exports[`GroupsElement render should pass createOptions object if it's add prop 
     createNewOption={[Function]}
     createPrompt="New group: "
     initial={Array []}
+    isOptionUnique={[Function]}
     isValidNewOption={[Function]}
     multi={true}
     name="Groups"

--- a/src/utils/index.test.tsx
+++ b/src/utils/index.test.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
+
 import {
     addCommas,
+    capitalize,
     containsOnlyLabelChars,
     emphasize,
     getBaseLanguage,
@@ -8,32 +10,34 @@ import {
     getLocalization,
     getSelectClass,
     hasErrorType,
+    isOptionUnique,
+    isRealValue,
     jsonEqual,
+    merge,
+    optionExists,
     properLabelLength,
     propertyExists,
+    push,
     renderIf,
     reorderList,
+    set,
     snakify,
+    splice,
     titleCase,
     toBoolMap,
-    validUUID,
-    isRealValue,
-    capitalize,
-    set,
-    merge,
     unset,
-    splice
-} from './index';
+    validUUID,
+    isValidNewOption
+} from '.';
 import { operatorConfigList } from '../config';
 import { ContactProperties } from '../flowTypes';
-import { configProviderContext } from '../testUtils/index';
-import { push } from './index';
+import { AssetType } from '../services/AssetService';
+import { configProviderContext } from '../testUtils';
 
 const {
     localization,
     nodes: [{ actions: [sendMsgAction] }]
 } = require('../../__test__/flows/customer_service.json');
-
 
 describe('utils', () => {
     describe('toBoolMap', () => {
@@ -302,6 +306,75 @@ describe('utils', () => {
     describe('splice', () => {
         it('should return an immutability-helper "splice" query', () => {
             expect(splice([[1]])).toEqual({ $splice: [[1]] });
+        });
+    });
+
+    describe('optionExists', () => {
+        const matchingOptions = [
+            {
+                name: 'Expected Delivery Date',
+                id: 'expected_delivery_date',
+                type: 'field'
+            }
+        ];
+
+        it('should return true if options exists', () => {
+            expect(optionExists('expected delivery date', matchingOptions)).toBeTruthy();
+        });
+
+        it('should return false if options does not exist', () => {
+            expect(optionExists('national id', [])).toBeFalsy();
+            expect(optionExists('national id', matchingOptions)).toBeFalsy();
+        });
+    });
+
+    describe('isOptionUnique', () => {
+        const isOptionUniqueSignature = {
+            labelKey: 'name',
+            valueKey: 'id',
+            options: []
+        };
+
+        it('should return true if new option is unique', () => {
+            const newOption = {
+                id: '2e020526-06a7-4acc-8f3f-90b4ceffdd91',
+                name: 'Age',
+                type: AssetType.Field
+            };
+
+            expect(
+                isOptionUnique({
+                    ...isOptionUniqueSignature,
+                    option: newOption
+                })
+            ).toBeTruthy();
+        });
+
+        it('should return false if new option is not unique', () => {
+            const newOption = {
+                id: 'name',
+                name: 'Name',
+                type: AssetType.Property
+            };
+
+            expect(
+                isOptionUnique({
+                    ...isOptionUniqueSignature,
+                    option: newOption
+                })
+            ).toBeFalsy();
+        });
+    });
+
+    describe('isValidNewOption', () => {
+        it('should return false if new option is invalid', () => {
+            expect(isValidNewOption({ label: '$$$' })).toBeFalsy();
+        });
+
+        it('should return true if new option is valid', () => {
+            const newGroup = { label: 'new group' };
+
+            expect(isValidNewOption(newGroup)).toBeTruthy();
         });
     });
 });

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -4,6 +4,7 @@ import { Action, Case, Exit, Languages, LocalizationMap, ContactProperties } fro
 import Localization, { LocalizedObject } from '../services/Localization';
 import * as variables from '../variables.scss';
 import { Query } from 'immutability-helper';
+import { IsValidNewOptionHandler, IsOptionUniqueHandler } from 'react-select';
 
 export const V4_UUID = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
 const LABEL_CHARS = /^[a-zA-Z0-9-][a-zA-Z0-9- ]*$/;
@@ -280,3 +281,13 @@ export const push = (arr: any[]): Query<any[]> => ({ $push: arr });
 
 // tslint:disable-next-line:array-type
 export const splice = (arr: Array<Array<any>>): Query<Array<Array<any>>> => ({ $splice: arr });
+
+export const optionExists = (newOptName: string, options: any[]) =>
+    options.find(({ name }) => name.toLowerCase().trim() === newOptName.toLowerCase().trim())
+        ? true
+        : false;
+
+export const isValidNewOption: IsValidNewOptionHandler = ({ label }) => isValidLabel(label);
+
+export const isOptionUnique: IsOptionUniqueHandler = ({ option, options, labelKey, valueKey }) =>
+    !propertyExists(option.name) && !optionExists(option.name, options);


### PR DESCRIPTION
- Solves the issue we were running into w/ `AttribElement` whereby whitespace wasn't 
being stripped from the value passed to the `createNewOption` handler.

- Extracts common handlers `isOptionUnique`, `isValidNewOption`, and `optionExists` out to utils. 