### PR TITLE
Small rendering fixes

### DIFF
--- a/src/component/Exit.scss
+++ b/src/component/Exit.scss
@@ -114,8 +114,9 @@
             span {
                 // TODO: style this so it's not variable
                 position: absolute;
-                left: -.05rem;
-                top: .03rem;
+                left: .03rem;
+                top: .06rem;
+                font-size: 11px;
             }
         }
     }

--- a/src/component/Exit.tsx
+++ b/src/component/Exit.tsx
@@ -5,6 +5,7 @@ import * as classNames from 'classnames/bind';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+
 import { ConfigProviderContext } from '../config';
 import { fakePropType } from '../config/ConfigProvider';
 import { Exit, FlowNode, LocalizationMap } from '../flowTypes';
@@ -168,7 +169,7 @@ export class ExitComp extends React.PureComponent<ExitProps, ExitState> {
         const confirmDelete =
             this.state.confirmDelete && this.props.exit.hasOwnProperty('destination_node_uuid');
         const confirm: JSX.Element = confirmDelete ? (
-            <span {...createClickHandler(this.onDisconnect)} className="icn-remove" />
+            <span {...createClickHandler(this.onDisconnect)} className="icn-cross" />
         ) : null;
         const exitClasses: string = cx({
             [styles.exit]: true,

--- a/src/component/SelectSearch/SelectSearch.test.ts
+++ b/src/component/SelectSearch/SelectSearch.test.ts
@@ -1,10 +1,11 @@
-import axiosMock from 'axios';
-import { FlowEditorConfig, ResultType } from '../../flowTypes';
+import * as config from '../../../__test__/config';
+import { ResultType } from '../../flowTypes';
+import AssetService from '../../services/AssetService';
 import {
     composeComponentTestUtils,
     configProviderContext,
-    Resp,
     flushPromises,
+    Resp,
     restoreSpies
 } from '../../testUtils';
 import { GROUP_NOT_FOUND, GROUP_PLACEHOLDER } from '../form/constants';
@@ -17,7 +18,8 @@ const baseProps: SelectSearchProps = {
     name: 'Groups',
     resultType: ResultType.group,
     placeholder: GROUP_PLACEHOLDER,
-    searchPromptText: GROUP_NOT_FOUND
+    searchPromptText: GROUP_NOT_FOUND,
+    assets: new AssetService(config).getGroupAssets()
 };
 
 const { setup, spyOn } = composeComponentTestUtils(SelectSearch, baseProps);
@@ -71,22 +73,39 @@ describe(SelectSearch.name, () => {
                 componentWillReceivePropsSpy.mockRestore();
             });
 
-            xit('should set state if it receives a new initial option through props', () => {
-                const setStateSpy = spyOn('setState');
-                const { wrapper } = setup();
-                /*
-                const initial = mapRespToSearchOpts(groupsResp);
-                const nextProps = { ...baseProps, initial };
-
-                wrapper.setProps(nextProps);
-
-                expect(setStateSpy).toHaveBeenCalledTimes(1);
-                expect(setStateSpy).toHaveBeenCalledWith({
-                    selections: initial
+            it('should change single selection', () => {
+                const { wrapper, instance, props } = setup(false, {
+                    $merge: { multi: false, onChange: jest.fn() }
                 });
 
-                setStateSpy.mockRestore();
-                */
+                instance.onChange({
+                    name: 'Subscribers',
+                    uuid: '33b28bac-b588-43e4-90de-fda77aeaf7c0'
+                });
+
+                expect(props.onChange).toHaveBeenCalledWith([
+                    { name: 'Subscribers', uuid: '33b28bac-b588-43e4-90de-fda77aeaf7c0' }
+                ]);
+            });
+
+            it('should add a new item', () => {
+                const { wrapper, instance, props } = setup(false, {
+                    $merge: { multi: false, onChange: jest.fn() }
+                });
+
+                instance.onChange({
+                    name: 'My New Group Name',
+                    uuid: '2a5e3a2d-326e-4aca-b91e-4aff20c9b4c5',
+                    isNew: true
+                });
+
+                expect(props.onChange).toHaveBeenCalledWith([
+                    {
+                        isNew: true,
+                        name: 'My New Group Name',
+                        uuid: '2a5e3a2d-326e-4aca-b91e-4aff20c9b4c5'
+                    }
+                ]);
             });
         });
     });

--- a/src/component/SelectSearch/SelectSearch.tsx
+++ b/src/component/SelectSearch/SelectSearch.tsx
@@ -249,7 +249,7 @@ export default class SelectSearch extends React.PureComponent<
                     valueKey="id"
                     labelKey="name"
                     multi={this.props.multi}
-                    clearable={this.props.multi}
+                    clearable={false}
                     searchable={true}
                     onBlurResetsInput={true}
                     filterOption={this.filterOption}
@@ -276,7 +276,7 @@ export default class SelectSearch extends React.PureComponent<
                     valueKey="id"
                     labelKey="name"
                     multi={this.props.multi}
-                    clearable={this.props.multi}
+                    clearable={false}
                     searchable={true}
                     onBlurResetsInput={true}
                     filterOption={this.filterOption}

--- a/src/component/SelectSearch/SelectSearch.tsx
+++ b/src/component/SelectSearch/SelectSearch.tsx
@@ -28,7 +28,7 @@ export interface SelectSearchProps {
     assets?: Assets;
     __className?: string;
     createPrompt?: string;
-    onChange?: (selections: Asset | Asset[]) => void;
+    onChange?: (selections: Asset[]) => void;
     isValidNewOption?: IsValidNewOptionHandler;
     isOptionUnique?: IsOptionUniqueHandler;
     createNewOption?: NewOptionCreatorHandler;
@@ -66,44 +66,17 @@ export default class SelectSearch extends React.PureComponent<
         }
     }
 
-    private onChange(selection: Asset): void {
-        // Account for null selections
-        if (!selection) {
-            return;
-        }
-
-        if (selection.isNew && this.props.assets) {
-            this.props.assets.add(selection);
-        }
-
-        // Convert to array to update state
-        const selections = [selection];
-
-        if (!isEqual(this.state.selections, selections)) {
-            if (this.props.onChange) {
-                this.props.onChange(selection);
-            }
-
-            this.setState(
-                {
-                    selections
-                },
-                () => this.select.focus()
-            );
-        }
+    public onChange(selection: Asset): void {
+        this.onChangeMulti([selection]);
     }
 
-    private onChangeMulti(selections: Asset[]): void {
+    public onChangeMulti(selections: Asset[]): void {
         if (this.props.assets) {
             for (const selection of selections) {
                 if (selection.isNew) {
                     this.props.assets.add(selection);
                 }
             }
-        }
-        // Account for null selections
-        if (!selections) {
-            return;
         }
 
         if (!isEqual(this.state.selections, selections)) {

--- a/src/component/SelectSearch/SelectValue.tsx
+++ b/src/component/SelectSearch/SelectValue.tsx
@@ -3,6 +3,7 @@ import { react as bindCallbacks } from 'auto-bind';
 import * as React from 'react';
 
 import { Asset } from '../../services/AssetService';
+import { renderIf } from '../../utils';
 import { getIconForAssetType } from './helper';
 
 export interface SelectValueProps {
@@ -24,15 +25,19 @@ export default class SelectValue extends React.PureComponent<SelectValueProps, {
     }
 
     public render(): JSX.Element {
+        console.log(this.props);
         return (
             <div className="Select-value">
-                <span
-                    data-spec="remove-button"
-                    onClick={this.handleRemove}
-                    className="Select-value-icon"
-                >
-                    x
-                </span>
+                {renderIf(this.props.onRemove)(
+                    <span
+                        data-spec="remove-button"
+                        onClick={this.handleRemove}
+                        className="Select-value-icon"
+                    >
+                        x
+                    </span>
+                )}
+
                 <span className="Select-value-label">
                     {getIconForAssetType(this.props.value.type)} {this.props.value.name}
                 </span>

--- a/src/component/SelectSearch/SelectValue.tsx
+++ b/src/component/SelectSearch/SelectValue.tsx
@@ -25,7 +25,6 @@ export default class SelectValue extends React.PureComponent<SelectValueProps, {
     }
 
     public render(): JSX.Element {
-        console.log(this.props);
         return (
             <div className="Select-value">
                 {renderIf(this.props.onRemove)(

--- a/src/component/SelectSearch/__snapshots__/SelectSearch.test.ts.snap
+++ b/src/component/SelectSearch/__snapshots__/SelectSearch.test.ts.snap
@@ -6,7 +6,7 @@ Object {
   "cache": Object {},
   "children": [Function],
   "className": undefined,
-  "clearable": undefined,
+  "clearable": false,
   "closeOnSelect": undefined,
   "filterOption": [Function],
   "ignoreAccents": false,
@@ -41,6 +41,7 @@ exports[`SelectSearch render should render self, children with required props 2`
   <Async
     autoload={true}
     cache={Object {}}
+    clearable={false}
     filterOption={[Function]}
     ignoreAccents={false}
     ignoreCase={false}
@@ -69,7 +70,7 @@ exports[`SelectSearch render should render self, children with required props 2`
       clearAllText="Clear all"
       clearRenderer={[Function]}
       clearValueText="Clear value"
-      clearable={true}
+      clearable={false}
       closeOnSelect={true}
       deleteRemoves={true}
       delimiter=","
@@ -116,7 +117,7 @@ exports[`SelectSearch render should render self, children with required props 2`
       valueKey="id"
     >
       <div
-        className="Select Select--single is-clearable is-searchable"
+        className="Select Select--single is-searchable"
       >
         <div
           className="Select-control"

--- a/src/component/SelectSearch/__snapshots__/SelectSearch.test.ts.snap
+++ b/src/component/SelectSearch/__snapshots__/SelectSearch.test.ts.snap
@@ -32,6 +32,15 @@ Object {
 
 exports[`SelectSearch render should render self, children with required props 2`] = `
 <SelectSearch
+  assets={
+    GroupAssets {
+      "assetType": "group",
+      "assets": Object {},
+      "endpoint": "/assets/groups.json",
+      "idProperty": "uuid",
+      "localStorage": true,
+    }
+  }
   name="Groups"
   placeholder="Enter the name of an existing group..."
   resultType="group"
@@ -101,7 +110,35 @@ exports[`SelectSearch render should render self, children with required props 2`
       openOnClick={true}
       openOnFocus={true}
       optionComponent={[Function]}
-      options={Array []}
+      options={
+        Array [
+          Object {
+            "id": "23ff7152-b588-43e4-90de-fda77aeaf7c0",
+            "name": "Customers",
+            "type": "group",
+          },
+          Object {
+            "id": "cdbf9e01-aaa7-4381-8259-ee042447bcac",
+            "name": "Early Adopters",
+            "type": "group",
+          },
+          Object {
+            "id": "33b28bac-b588-43e4-90de-fda77aeaf7c0",
+            "name": "Subscribers",
+            "type": "group",
+          },
+          Object {
+            "id": "afaba971-8943-4dd8-860b-3561ed4f1fe1",
+            "name": "Testers",
+            "type": "group",
+          },
+          Object {
+            "id": "2429d573-80d7-47f8-879f-f2ba442a1bfd",
+            "name": "Unsatisfied Customers",
+            "type": "group",
+          },
+        ]
+      }
       pageSize={5}
       placeholder="Enter the name of an existing group..."
       removeSelected={true}

--- a/src/component/SelectSearch/helper.tsx
+++ b/src/component/SelectSearch/helper.tsx
@@ -8,6 +8,8 @@ export const getIconForAssetType = (assetType: AssetType): JSX.Element => {
             return <span className="icn-group" />;
         case AssetType.Label:
             return <span className="icn-label" />;
+        case AssetType.Flow:
+            return <span className="icn-split" />;
     }
     return null;
 };

--- a/src/component/actions/Action/Action.scss
+++ b/src/component/actions/Action/Action.scss
@@ -20,7 +20,7 @@
 
     &.add_input_labels, &.send_msg, &.set_contact_field, &.set_contact_property, 
     &.add_contact_groups, &.remove_contact_groups, &.set_run_result, 
-    &.send_email, &.send_broadcast, &.missing {
+    &.send_email, &.send_broadcast, &.missing, &.start_flow {
         width: $node_width - $action_padding * 2;
         padding: $action_padding;
     }

--- a/src/component/actions/Action/Action.tsx
+++ b/src/component/actions/Action/Action.tsx
@@ -3,8 +3,9 @@ import * as classNames from 'classnames/bind';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { getTypeConfig } from '../../../config';
-import { ConfigProviderContext } from '../../../config';
+
+import { ConfigProviderContext, getTypeConfig } from '../../../config';
+import { fakePropType } from '../../../config/ConfigProvider';
 import { Types } from '../../../config/typeConfigs';
 import { AnyAction, FlowNode, LocalizationMap } from '../../../flowTypes';
 import {
@@ -21,7 +22,6 @@ import { Language } from '../../LanguageSelector';
 import * as shared from '../../shared.scss';
 import TitleBar from '../../TitleBar';
 import * as styles from './Action.scss';
-import { fakePropType } from '../../../config/ConfigProvider';
 
 export interface ActionWrapperPassedProps {
     thisNodeDragging: boolean;
@@ -149,6 +149,7 @@ export class ActionWrapper extends React.Component<ActionWrapperProps> {
         const showRemoval = !this.props.translating;
         const showMove = !this.props.first && !this.props.translating;
 
+        console.log(actionClass);
         return (
             <div
                 id={`action-${this.props.action.uuid}`}

--- a/src/component/actions/Action/Action.tsx
+++ b/src/component/actions/Action/Action.tsx
@@ -149,7 +149,6 @@ export class ActionWrapper extends React.Component<ActionWrapperProps> {
         const showRemoval = !this.props.translating;
         const showMove = !this.props.first && !this.props.translating;
 
-        console.log(actionClass);
         return (
             <div
                 id={`action-${this.props.action.uuid}`}

--- a/src/component/actions/StartFlow/StartFlow.test.ts
+++ b/src/component/actions/StartFlow/StartFlow.test.ts
@@ -1,7 +1,7 @@
 import { StartFlow } from '../../../flowTypes';
 import { composeComponentTestUtils } from '../../../testUtils';
 import { createStartFlowAction } from '../../../testUtils/assetCreators';
-import StartFlowComp, { getStartFlowMarkup } from './StartFlow';
+import StartFlowComp from './StartFlow';
 
 const startFlowAction = createStartFlowAction();
 
@@ -11,9 +11,7 @@ describe(StartFlowComp.name, () => {
     describe('render', () => {
         it('should render flow name', () => {
             const { wrapper, props } = setup();
-            expect(
-                wrapper.containsMatchingElement(getStartFlowMarkup(props.flow.name))
-            ).toBeTruthy();
+            expect(wrapper.text()).toEqual(startFlowAction.flow.name);
             expect(wrapper).toMatchSnapshot();
         });
     });

--- a/src/component/actions/StartFlow/StartFlow.tsx
+++ b/src/component/actions/StartFlow/StartFlow.tsx
@@ -1,11 +1,16 @@
 import * as React from 'react';
+
 import { StartFlow } from '../../../flowTypes';
+import { AssetType } from '../../../services/AssetService';
+import { renderAssetList } from '../helpers';
 import * as styles from './StartFlow.scss';
 
 // tslint:disable-next-line:variable-name
 export const getStartFlowMarkup = (name: string) => <div className={styles.startFlow}>{name}</div>;
 
-const StartFlowComp: React.SFC<StartFlow> = ({ flow: { name } }): JSX.Element =>
-    getStartFlowMarkup(name);
+const StartFlowComp: React.SFC<StartFlow> = ({ flow: { name, uuid } }): JSX.Element => (
+    <>{renderAssetList([{ name, id: uuid, type: AssetType.Flow }])}</>
+);
+getStartFlowMarkup(name);
 
 export default StartFlowComp;

--- a/src/component/actions/StartFlow/StartFlow.tsx
+++ b/src/component/actions/StartFlow/StartFlow.tsx
@@ -3,14 +3,9 @@ import * as React from 'react';
 import { StartFlow } from '../../../flowTypes';
 import { AssetType } from '../../../services/AssetService';
 import { renderAssetList } from '../helpers';
-import * as styles from './StartFlow.scss';
-
-// tslint:disable-next-line:variable-name
-export const getStartFlowMarkup = (name: string) => <div className={styles.startFlow}>{name}</div>;
 
 const StartFlowComp: React.SFC<StartFlow> = ({ flow: { name, uuid } }): JSX.Element => (
     <>{renderAssetList([{ name, id: uuid, type: AssetType.Flow }])}</>
 );
-getStartFlowMarkup(name);
 
 export default StartFlowComp;

--- a/src/component/actions/StartFlow/__snapshots__/StartFlow.test.ts.snap
+++ b/src/component/actions/StartFlow/__snapshots__/StartFlow.test.ts.snap
@@ -1,9 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StartFlowComp render should render flow name 1`] = `
-<div
-  className="startFlow"
->
-  Colors
-</div>
+<React.Fragment>
+  <div
+    className="nodeAsset"
+    key="start_flow-0"
+  >
+    <span
+      className="nodeLabel icn-split"
+    />
+    Colors
+  </div>
+</React.Fragment>
 `;

--- a/src/component/actions/helpers.tsx
+++ b/src/component/actions/helpers.tsx
@@ -4,7 +4,7 @@ import { Asset, AssetType } from '../../services/AssetService';
 
 const styles = require('../shared.scss');
 
-export const renderAssetList = (assets: Asset[], max: number): JSX.Element[] => {
+export const renderAssetList = (assets: Asset[], max: number = 10): JSX.Element[] => {
     return assets.reduce((elements, asset, idx) => {
         if (idx <= max - 1) {
             elements.push(renderAsset(asset));
@@ -28,6 +28,13 @@ export const renderAsset = (asset: Asset) => {
             return (
                 <div className={styles.nodeAsset} key={asset.id}>
                     <span className={`${styles.nodeLabel} icn-label`} />
+                    {asset.name}
+                </div>
+            );
+        case AssetType.Flow:
+            return (
+                <div className={styles.nodeAsset} key={asset.id}>
+                    <span className={`${styles.nodeLabel} icn-split`} />
                     {asset.name}
                 </div>
             );

--- a/src/component/form/AttribElement.test.tsx
+++ b/src/component/form/AttribElement.test.tsx
@@ -77,7 +77,7 @@ describe(AttribElement.name, () => {
                 const setStateSpy = spyOn('setState');
                 const { wrapper, instance } = setup();
 
-                instance.onChange(existingField);
+                instance.onChange([existingField]);
 
                 expect(setStateSpy).toHaveBeenCalledTimes(1);
                 expect(setStateSpy).toHaveBeenCalledWith({ attribute: existingField });
@@ -90,7 +90,7 @@ describe(AttribElement.name, () => {
                 // tslint:disable-next-line:no-shadowed-variable
                 const { wrapper, instance, props: { initial } } = setup();
 
-                instance.onChange(initial);
+                instance.onChange([initial]);
 
                 expect(setStateSpy).toHaveBeenCalledTimes(0);
 

--- a/src/component/form/AttribElement.tsx
+++ b/src/component/form/AttribElement.tsx
@@ -53,7 +53,8 @@ export default class AttribElement extends React.Component<AttribElementProps, A
         this.onChange = this.onChange.bind(this);
     }
 
-    private onChange(attribute: Asset): void {
+    private onChange(selected: Asset[]): void {
+        const attribute = selected[0];
         if (!isEqual(this.state.attribute, attribute)) {
             this.setState({ attribute });
         }

--- a/src/component/form/FlowElement.tsx
+++ b/src/component/form/FlowElement.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
+
+import { ResultType } from '../../flowTypes';
+import { Asset, Assets, AssetType } from '../../services/AssetService';
 import { getSelectClass } from '../../utils';
 import SelectSearch from '../SelectSearch/SelectSearch';
 import FormElement, { FormElementProps } from './FormElement';
-import { ResultType } from '../../flowTypes';
-import { Assets, Asset, AssetType } from '../../services/AssetService';
 
 interface FlowElementProps extends FormElementProps {
     flow: { name: string; uuid: string };
@@ -40,9 +41,9 @@ export default class FlowElement extends React.Component<FlowElementProps, FlowS
         this.onChange = this.onChange.bind(this);
     }
 
-    private onChange(flow: any): void {
+    private onChange(selected: Asset[]): void {
         this.setState({
-            flow
+            flow: selected[0]
         });
     }
 

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -667,7 +667,7 @@ export const onUpdateRouter = (node: RenderNode) => (
         node.node = mutators.uniquifyNode(node.node);
     }
 
-    if (nodeToEdit && actionToEdit) {
+    if (nodeToEdit && actionToEdit && previousNode) {
         const actionToSplice = previousNode.node.actions.find(
             (action: Action) => action.uuid === actionToEdit.uuid
         );


### PR DESCRIPTION
* Fix stray 'x' on single select widgets
* Fix missing styling on start flow action
* Render start flow with shared asset list renderer
* Fix switching to a split when there is no previous node