### PR TITLE
Experiment: Always add result name to certain splits 

### DIFF
--- a/src/component/NodeEditor/NodeEditor.tsx
+++ b/src/component/NodeEditor/NodeEditor.tsx
@@ -31,7 +31,7 @@ import {
     UINodeTypes,
     Wait,
     WaitTypes,
-    WebhookExitNames
+    WebhookExitNames,
 } from '../../flowTypes';
 import { Asset } from '../../services/AssetService';
 import { LocalizedObject } from '../../services/Localization';
@@ -56,7 +56,7 @@ import {
     updateShowResultName,
     UpdateShowResultName,
     UpdateUserAddingAction,
-    updateUserAddingAction
+    updateUserAddingAction,
 } from '../../store';
 import { RenderNode } from '../../store/flowContext';
 import { NodeEditorForm, NodeEditorSettings } from '../../store/nodeEditor';
@@ -291,6 +291,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
             include: [
                 /^get/,
                 /^on/,
+                /^handle/,
                 /Ref$/,
                 /^get/,
                 /^add/,
@@ -367,7 +368,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
         this.props.updateShowResultName(true);
     }
 
-    private onResultNameChange(resultName: string): void {
+    private handleResultNameChange(resultName: string): void {
         this.props.updateResultName(resultName);
     }
 
@@ -542,7 +543,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
                     name="Result Name"
                     showLabel={true}
                     entry={{ value: this.props.resultName }}
-                    onChange={this.onResultNameChange}
+                    onChange={this.handleResultNameChange}
                     helpText="By naming the result, you can reference it later using @run.results.whatever_the_name_is"
                 />
             );

--- a/src/store/flowEditor.test.ts
+++ b/src/store/flowEditor.test.ts
@@ -1,4 +1,5 @@
 import { v4 as generateUUID } from 'uuid';
+
 import { configProviderContext } from '../testUtils';
 import Constants from './constants';
 import { RenderNode } from './flowContext';
@@ -26,9 +27,9 @@ import {
     updateNodeEditorOpen,
     updatePendingConnection,
     updatePendingConnections,
-    updateTranslating
+    updateTranslating,
 } from './flowEditor';
-import { getGhostNode } from './helpers';
+import { getFlowComponents, getGhostNode } from './helpers';
 
 const flowsResp = require('../../__test__/assets/flows.json');
 const boringFlow = require('../../__test__/flows/boring.json');
@@ -157,8 +158,8 @@ describe('flowEditor action creators', () => {
                 ui: boringFlow._ui.nodes[boringFlow.nodes[0].uuid],
                 inboundConnections: {}
             };
-
-            const ghostNode = getGhostNode(fromNode, boringFlow);
+            const { renderNodeMap } = getFlowComponents(boringFlow);
+            const ghostNode = getGhostNode(fromNode, renderNodeMap);
             const expectedAction = {
                 type: Constants.UPDATE_GHOST_NODE,
                 payload: {

--- a/src/store/helpers.test.ts
+++ b/src/store/helpers.test.ts
@@ -10,7 +10,7 @@ import {
     getLocalizations,
     getOrderedNodes,
     getSuggestedResultName,
-    getUniqueDestinations
+    getUniqueDestinations,
 } from './helpers';
 
 const mutate = require('immutability-helper');
@@ -46,7 +46,7 @@ describe('helpers', () => {
         const nodes = getFlowComponents(definition).renderNodeMap;
 
         it('should suggest response names', () => {
-            const suggestison = getSuggestedResultName({
+            const suggestion = getSuggestedResultName({
                 node0: {
                     node: { uuid: generateUUID(), actions: [], exits: [] },
                     ui: { position: { left: 100, top: 100 } },
@@ -54,7 +54,7 @@ describe('helpers', () => {
                 }
             });
 
-            expect(suggestison).toBe('Response 2');
+            expect(suggestion).toBe('Result 1');
         });
 
         it('should get unique destinations', () => {

--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -59,12 +59,8 @@ export const getActionIndex = (node: FlowNode, actionUUID: string) => {
     throw new Error('Cannot find action ' + actionUUID);
 };
 
-/**
- * Gets a suggested result name based on the current number of waits
- * in the current definition
- */
-export const getSuggestedResultName = (nodes: RenderNodeMap) => {
-    let count = 0;
+export const getResultCount = (nodes: RenderNodeMap) => {
+    let count = 1;
     // tslint:disable-next-line:forin
     for (const key in nodes) {
         const { node } = nodes[key];
@@ -72,8 +68,14 @@ export const getSuggestedResultName = (nodes: RenderNodeMap) => {
             count += 1;
         }
     }
-    return `Result ${count + 1}`;
+    return count;
 };
+
+/**
+ * Gets a suggested result name based on the current number of waits
+ * in the current definition
+ */
+export const getSuggestedResultName = (nodes: RenderNodeMap) => `Result ${getResultCount(nodes)}`;
 
 export const getLocalizations = (
     node: FlowNode,

--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -3,6 +3,7 @@ import { v4 as generateUUID } from 'uuid';
 import { DefaultExitNames } from '../component/NodeEditor/NodeEditor';
 import { Types } from '../config/typeConfigs';
 import {
+    AddLabels,
     AnyAction,
     ChangeGroups,
     Exit,
@@ -15,7 +16,6 @@ import {
     SwitchRouter,
     UINodeTypes,
     WaitTypes,
-    AddLabels
 } from '../flowTypes';
 import { Asset, AssetType } from '../services/AssetService';
 import Localization, { LocalizedObject } from '../services/Localization';
@@ -64,7 +64,15 @@ export const getActionIndex = (node: FlowNode, actionUUID: string) => {
  * in the current definition
  */
 export const getSuggestedResultName = (nodes: RenderNodeMap) => {
-    return 'Response ' + (Object.keys(nodes).length + 1);
+    let count = 0;
+    // tslint:disable-next-line:forin
+    for (const key in nodes) {
+        const { node } = nodes[key];
+        if (node.router) {
+            count += 1;
+        }
+    }
+    return `Result ${count + 1}`;
 };
 
 export const getLocalizations = (

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -17,17 +17,11 @@ import {
     Languages,
     SendMsg,
     StickyNote,
-    SwitchRouter
+    SwitchRouter,
 } from '../flowTypes';
 import AssetService, { Asset, Assets } from '../services/AssetService';
 import { NODE_SPACING, timeEnd, timeStart } from '../utils';
-import {
-    RenderNode,
-    RenderNodeMap,
-    updateDefinition,
-    updateLocalizations,
-    updateNodes
-} from './flowContext';
+import { RenderNode, RenderNodeMap, updateDefinition, updateLocalizations, updateNodes } from './flowContext';
 import {
     updateCreateNodePosition,
     updateDragSelection,
@@ -35,7 +29,7 @@ import {
     updateGhostNode,
     updateNodeDragging,
     updateNodeEditorOpen,
-    updatePendingConnection
+    updatePendingConnection,
 } from './flowEditor';
 import {
     determineConfigType,
@@ -44,7 +38,7 @@ import {
     getCollision,
     getFlowComponents,
     getGhostNode,
-    getLocalizations
+    getLocalizations,
 } from './helpers';
 import * as mutators from './mutators';
 import {
@@ -58,7 +52,7 @@ import {
     updateShowResultName,
     updateTimeout,
     updateTypeConfig,
-    updateUserAddingAction
+    updateUserAddingAction,
 } from './nodeEditor';
 import AppState from './state';
 
@@ -455,10 +449,11 @@ export const handleTypeConfigChange = (typeConfig: Type, actionToEdit: AnyAction
     getState: GetState
 ) => {
     dispatch(updateTypeConfig(typeConfig));
+    const { type } = typeConfig;
     if (typeConfig.formHelper) {
         // tslint:disable-next-line:no-shadowed-variable
-        const action = actionToEdit && actionToEdit.type === typeConfig.type ? actionToEdit : null;
-        dispatch(updateForm(typeConfig.formHelper.actionToState(action, typeConfig.type)));
+        const action = actionToEdit && actionToEdit.type === type ? actionToEdit : null;
+        dispatch(updateForm(typeConfig.formHelper.actionToState(action, type)));
     } else {
         dispatch(updateForm(null));
     }


### PR DESCRIPTION
Always adds a suggested result name to `wait_for_response`, `split_by_expression` and `split_by_group_membership` nodes. 

Things to consider:

- Update nodes to contain suggested result names when flow is initialized. 
- Sort and apply suggested result names when existing node is changed to a switch router and saved with a suggested result name. Right now, updating the first node in the colors flow to a `wait_for_response` node will apply the suggested result name `Result 4`; this would make that `Result 1`. 