### PR TITLE
Move nodeToEdit and actionToEdit

### DIFF
--- a/src/component/Flow.test.ts
+++ b/src/component/Flow.test.ts
@@ -11,7 +11,7 @@ import {
     isDraggingBack,
     nodesContainerSpecId,
     nodeSpecId,
-    REPAINT_TIMEOUT,
+    REPAINT_TIMEOUT
 } from '../component/Flow';
 import { Types } from '../config/typeConfigs';
 import { getActivity } from '../external';
@@ -399,10 +399,9 @@ describe(Flow.name, () => {
                 );
                 expect(props.updateCreateNodePosition).toHaveBeenCalledTimes(1);
                 expect(props.onOpenNodeEditor).toHaveBeenCalledTimes(1);
-                expect(props.onOpenNodeEditor).toHaveBeenCalledWith(
-                    props.ghostNode,
-                    null,
-                );
+                expect(props.onOpenNodeEditor).toHaveBeenCalledWith({
+                    originalNode: props.ghostNode
+                });
             });
         });
 

--- a/src/component/Flow.tsx
+++ b/src/component/Flow.tsx
@@ -218,7 +218,7 @@ export class Flow extends React.Component<FlowStoreProps, {}> {
             this.props.updateCreateNodePosition({ left, top });
 
             // Bring up the node editor
-            this.props.onOpenNodeEditor(this.props.ghostNode, null);
+            this.props.onOpenNodeEditor({ originalNode: this.props.ghostNode });
         }
 
         // To-do: mock this out

--- a/src/component/Modal.tsx
+++ b/src/component/Modal.tsx
@@ -38,7 +38,7 @@ export interface ModalPassedProps {
 
 export interface ModalStoreProps {
     translating: boolean;
-    nodeToEdit: FlowNode;
+    originalNode: FlowNode;
     type: Types;
 }
 
@@ -130,8 +130,8 @@ export class Modal extends React.Component<ModalProps, ModalState> {
             if (hasAdvanced) {
                 /** Don't show advanced settings for SwitchRouter unless we have cases to translate */
                 let cases: Case[];
-                if (this.props.nodeToEdit && this.props.nodeToEdit.router) {
-                    ({ cases } = this.props.nodeToEdit.router as SwitchRouter);
+                if (this.props.originalNode && this.props.originalNode.router) {
+                    ({ cases } = this.props.originalNode.router as SwitchRouter);
                 }
                 if (isFrontForm) {
                     if (cases && !cases.length) {
@@ -221,10 +221,11 @@ export class Modal extends React.Component<ModalProps, ModalState> {
 /* istanbul ignore next */
 const mapStateToProps = ({
     flowEditor: { editorUI: { translating } },
-    nodeEditor: { nodeToEdit, typeConfig }
+    nodeEditor: { settings: { originalNode }, typeConfig }
 }: AppState) => ({
+    // TODO: Modal should not care about flow stuff
     translating,
-    nodeToEdit,
+    originalNode,
     type: typeConfig.type
 });
 

--- a/src/component/Node.tsx
+++ b/src/component/Node.tsx
@@ -271,11 +271,7 @@ export class NodeComp extends React.Component<NodeProps, NodeState> {
     // ./Action/Action handles click logic for Action nodes.
     private onClick(event: React.MouseEvent<HTMLDivElement>): void {
         if (!this.props.nodeDragging) {
-            // prettier-ignore
-            this.props.onOpenNodeEditor(
-                this.props.node,
-                null,
-            );
+            this.props.onOpenNodeEditor({ originalNode: this.props.node });
         }
     }
 

--- a/src/component/NodeEditor/NodeEditor.test.ts
+++ b/src/component/NodeEditor/NodeEditor.test.ts
@@ -20,10 +20,8 @@ const switchWithTimeout: FlowNode = update(colorsFlow.nodes[1], {
 });
 
 const baseProps: NodeEditorProps = {
-    nodeToEdit: switchWithTimeout,
     language: { iso: 'eng', name: 'English' },
     nodeEditorOpen: true,
-    actionToEdit: null,
     localizations: [],
     definition: colorsFlow,
     translating: false,
@@ -46,7 +44,7 @@ const baseProps: NodeEditorProps = {
     updateShowResultName: jest.fn(),
     plumberConnectExit: jest.fn(),
     plumberRepaintForDuration: jest.fn(),
-    settings: { showAdvanced: false }
+    settings: { showAdvanced: false, originalNode: switchWithTimeout }
 };
 
 const { setup, spyOn } = composeComponentTestUtils(NodeEditor, baseProps);
@@ -66,7 +64,7 @@ describe(NodeEditor.name, () => {
                     onUpdateRouter: setMock()
                 });
                 const kases = casePropsFromNode({
-                    nodeToEdit: props.nodeToEdit,
+                    nodeToEdit: props.settings.originalNode,
                     handleCaseChanged: jest.fn(),
                     handleCaseRemoved: jest.fn()
                 });

--- a/src/component/NodeEditor/NodeEditor.tsx
+++ b/src/component/NodeEditor/NodeEditor.tsx
@@ -31,7 +31,7 @@ import {
     UINodeTypes,
     Wait,
     WaitTypes,
-    WebhookExitNames,
+    WebhookExitNames
 } from '../../flowTypes';
 import { Asset } from '../../services/AssetService';
 import { LocalizedObject } from '../../services/Localization';
@@ -56,7 +56,7 @@ import {
     updateShowResultName,
     UpdateShowResultName,
     UpdateUserAddingAction,
-    updateUserAddingAction,
+    updateUserAddingAction
 } from '../../store';
 import { RenderNode } from '../../store/flowContext';
 import { NodeEditorForm, NodeEditorSettings } from '../../store/nodeEditor';
@@ -97,10 +97,8 @@ export interface NodeEditorPassedProps {
 }
 
 export interface NodeEditorStoreProps {
-    nodeToEdit: FlowNode;
     language: Asset;
     nodeEditorOpen: boolean;
-    actionToEdit: Action;
     localizations: LocalizedObject[];
     definition: FlowDefinition;
     translating: boolean;
@@ -359,7 +357,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
     private onTypeChange(config: Type): void {
         this.widgets = {};
         this.advancedWidgets = {};
-        this.props.handleTypeConfigChange(config, this.props.actionToEdit);
+        this.props.handleTypeConfigChange(config, this.props.settings.originalAction);
     }
 
     private onShowNameField(): void {
@@ -382,8 +380,8 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
         // create mapping of our old exit uuids to old exit settings
         const previousExitMap: { [uuid: string]: Exit } = {};
 
-        if (this.props.nodeToEdit.exits) {
-            for (const exit of this.props.nodeToEdit.exits) {
+        if (this.props.settings.originalNode.exits) {
+            for (const exit of this.props.settings.originalNode.exits) {
                 previousExitMap[exit.uuid] = exit;
             }
         }
@@ -420,8 +418,8 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
                 // couldn't find a new exit, look through our old ones
                 if (!existingExit) {
                     // look through our previous cases for a match
-                    if (this.props.nodeToEdit.exits) {
-                        for (const exit of this.props.nodeToEdit.exits) {
+                    if (this.props.settings.originalNode.exits) {
+                        for (const exit of this.props.settings.originalNode.exits) {
                             if (newCase.exitName && exit.name) {
                                 if (
                                     exit.name.toLowerCase() ===
@@ -464,10 +462,10 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
         // add in our default exit
         let defaultUUID = generateUUID();
         if (
-            this.props.nodeToEdit.router &&
-            this.props.nodeToEdit.router.type === RouterTypes.switch
+            this.props.settings.originalNode.router &&
+            this.props.settings.originalNode.router.type === RouterTypes.switch
         ) {
-            const router = this.props.nodeToEdit.router as SwitchRouter;
+            const router = this.props.settings.originalNode.router as SwitchRouter;
             if (router && router.default_exit_uuid) {
                 defaultUUID = router.default_exit_uuid;
             }
@@ -475,7 +473,10 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
 
         let defaultName = DefaultExitNames.All_Responses;
 
-        if (this.props.nodeToEdit.wait && this.props.nodeToEdit.wait.type === 'exp') {
+        if (
+            this.props.settings.originalNode.wait &&
+            this.props.settings.originalNode.wait.type === 'exp'
+        ) {
             defaultName = DefaultExitNames.Any_Value;
         }
 
@@ -497,7 +498,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
         // is a timeout set?
         if (this.props.timeout) {
             // do we have an existing timeout exit?
-            const existingExit = this.props.nodeToEdit.exits.find(
+            const existingExit = this.props.settings.originalNode.exits.find(
                 ({ name }) => name === DefaultExitNames.No_Response
             );
             const timeoutExit: Exit = {
@@ -571,7 +572,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
      * and this router has a translation for the 'Other' case, lose it.
      */
     private cleanUpLocalizations(cases: CaseElementProps[]): void {
-        const { uuid: nodeUUID, exits: nodeExits } = this.props.nodeToEdit;
+        const { uuid: nodeUUID, exits: nodeExits } = this.props.settings.originalNode;
         const exitMap: { [uuid: string]: Exit } = mapExits(nodeExits);
         const updates: LocalizationUpdates = [];
         let lang: string;
@@ -585,10 +586,11 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
                         // don't prune if we have a timeout
                         if (
                             (exitMatch.name === DefaultExitNames.All_Responses &&
-                                (this.props.nodeToEdit.wait &&
-                                    !this.props.nodeToEdit.wait.timeout)) ||
+                                (this.props.settings.originalNode.wait &&
+                                    !this.props.settings.originalNode.wait.timeout)) ||
                             (exitMatch.name === DefaultExitNames.Other &&
-                                (this.props.nodeToEdit.wait && !this.props.nodeToEdit.wait.timeout))
+                                (this.props.settings.originalNode.wait &&
+                                    !this.props.settings.originalNode.wait.timeout))
                         ) {
                             lang = iso;
                             updates.push({ uuid: localizationUUID });
@@ -604,25 +606,28 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
     private getLocalizedExits(widgets: {
         [name: string]: any;
     }): Array<{ uuid: string; translations: any }> {
-        return this.props.nodeToEdit.exits.reduce((results, { uuid: exitUUID }: Exit) => {
-            const input = widgets[exitUUID];
+        return this.props.settings.originalNode.exits.reduce(
+            (results, { uuid: exitUUID }: Exit) => {
+                const input = widgets[exitUUID];
 
-            if (input) {
-                // We save localized values as string arrays
-                const value =
-                    input.wrappedInstance.state.value.constructor === Array
-                        ? input.wrappedInstance.state.value[0].trim()
-                        : input.wrappedInstance.state.value.trim();
+                if (input) {
+                    // We save localized values as string arrays
+                    const value =
+                        input.wrappedInstance.state.value.constructor === Array
+                            ? input.wrappedInstance.state.value[0].trim()
+                            : input.wrappedInstance.state.value.trim();
 
-                if (value) {
-                    results.push({ uuid: exitUUID, translations: { name: [value] } });
-                } else {
-                    results.push({ uuid: exitUUID, translations: null });
+                    if (value) {
+                        results.push({ uuid: exitUUID, translations: { name: [value] } });
+                    } else {
+                        results.push({ uuid: exitUUID, translations: null });
+                    }
                 }
-            }
 
-            return results;
-        }, []);
+                return results;
+            },
+            []
+        );
     }
 
     private saveLocalizations(widgets: { [name: string]: any }, cases?: CaseElementProps[]): void {
@@ -639,7 +644,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
         [name: string]: any;
     }): Array<{ uuid: string; translations: any }> {
         const results: Array<{ uuid: string; translations: any }> = [];
-        const { cases } = this.props.nodeToEdit.router as SwitchRouter;
+        const { cases } = this.props.settings.originalNode.router as SwitchRouter;
 
         cases.forEach(({ uuid: caseUUID }) => {
             const input = widgets[caseUUID];
@@ -672,7 +677,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
             return null;
         }
 
-        const exits: Exit[] = this.props.nodeToEdit.exits.reduce(
+        const exits: Exit[] = this.props.settings.originalNode.exits.reduce(
             (exitList, { uuid: exitUUID, name: exitName }) => {
                 const [localized] = this.props.localizations.filter(
                     (localizedObject: LocalizedObject) =>
@@ -850,7 +855,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
     ): RenderNode {
         return {
             node: {
-                uuid: this.props.nodeToEdit.uuid,
+                uuid: this.props.settings.originalNode.uuid,
                 actions,
                 router,
                 exits,
@@ -895,7 +900,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
     public updateSubflowRouter(): void {
         // prettier-ignore
         const action = getAction(
-            this.props.actionToEdit,
+            this.props.settings.originalAction,
             this.props.typeConfig
         );
 
@@ -921,11 +926,11 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
         let cases: Case[];
 
         // TODO: we should probably just be passing down RenderNode
-        const renderNode = this.props.nodes[this.props.nodeToEdit.uuid];
+        const renderNode = this.props.nodes[this.props.settings.originalNode.uuid];
 
         if (renderNode && renderNode.ui.type === 'subflow') {
-            ({ exits } = this.props.nodeToEdit);
-            ({ cases } = this.props.nodeToEdit.router as SwitchRouter);
+            ({ exits } = this.props.settings.originalNode);
+            ({ cases } = this.props.settings.originalNode.router as SwitchRouter);
         } else {
             // Otherwise, let's create some new ones
             exits = [
@@ -972,7 +977,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
     }
 
     private updateWebhookRouter(): void {
-        const action = getAction(this.props.actionToEdit, this.props.typeConfig);
+        const action = getAction(this.props.settings.originalAction, this.props.typeConfig);
         const urlEle = this.widgets.URL.wrappedInstance;
 
         // Determine method
@@ -1018,12 +1023,14 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
         let cases: Case[] = [];
 
         // TODO: we should probably just be passing down RenderNode
-        const renderNode = this.props.nodes[this.props.nodeToEdit.uuid];
+        const renderNode = this.props.nodes[this.props.settings.originalNode.uuid];
 
         // If we were already a webhook, lean on those exits and cases
         if (renderNode && renderNode.ui.type === 'webhook') {
-            this.props.nodeToEdit.exits.forEach(exit => exits.push(exit));
-            (this.props.nodeToEdit.router as SwitchRouter).cases.forEach(kase => cases.push(kase));
+            this.props.settings.originalNode.exits.forEach(exit => exits.push(exit));
+            (this.props.settings.originalNode.router as SwitchRouter).cases.forEach(kase =>
+                cases.push(kase)
+            );
         } else {
             // Otherwise, let's create some new ones
             exits.push(
@@ -1147,7 +1154,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
     }
 
     private getSides(): Sides {
-        const { actionToEdit, typeConfig } = this.props;
+        const { settings: { originalAction: actionToEdit }, typeConfig } = this.props;
         const action = getAction(actionToEdit, typeConfig);
         let updateRouter: Function;
 
@@ -1247,22 +1254,10 @@ const mapStateToProps = ({
         editorUI: { language, translating, nodeEditorOpen },
         flowUI: { pendingConnection }
     },
-    nodeEditor: {
-        nodeToEdit,
-        actionToEdit,
-        typeConfig,
-        resultName,
-        showResultName,
-        settings,
-        operand,
-        timeout,
-        form
-    }
+    nodeEditor: { typeConfig, resultName, showResultName, settings, operand, timeout, form }
 }: AppState) => ({
-    nodeToEdit,
     language,
     nodeEditorOpen,
-    actionToEdit,
     definition,
     localizations,
     nodes,

--- a/src/component/actions/Action/Action.test.ts
+++ b/src/component/actions/Action/Action.test.ts
@@ -159,7 +159,9 @@ describe(ActionWrapper.name, () => {
                 instance.onClick(mockEvent);
 
                 expect(props.onOpenNodeEditor).toHaveBeenCalledTimes(1);
-                expect(props.onOpenNodeEditor).toHaveBeenCalledWith(props.node, props.action, {
+                expect(props.onOpenNodeEditor).toHaveBeenCalledWith({
+                    originalNode: props.node,
+                    originalAction: props.action,
                     showAdvanced: false
                 });
             });

--- a/src/component/actions/Action/Action.tsx
+++ b/src/component/actions/Action/Action.tsx
@@ -15,7 +15,7 @@ import {
     moveActionUp,
     OnOpenNodeEditor,
     onOpenNodeEditor,
-    removeAction,
+    removeAction
 } from '../../../store';
 import { createClickHandler, getLocalization } from '../../../utils';
 import * as shared from '../../shared.scss';
@@ -70,7 +70,11 @@ export class ActionWrapper extends React.Component<ActionWrapperProps> {
         if (!this.props.thisNodeDragging) {
             event.preventDefault();
             event.stopPropagation();
-            this.props.onOpenNodeEditor(this.props.node, this.props.action, { showAdvanced });
+            this.props.onOpenNodeEditor({
+                originalNode: this.props.node,
+                originalAction: this.props.action,
+                showAdvanced
+            });
         }
     }
 

--- a/src/component/form/CaseElement.scss
+++ b/src/component/form/CaseElement.scss
@@ -76,24 +76,26 @@ textarea:focus, input:focus{
 }
 
 .dnd-icon {
-    color: #ccc;
+    color: #aaa;
     font-weight: bold;
     padding-top: 9px;
     padding-right: 5px;
     float: left;
     opacity: 0;
-    font-size: 18px;
+    font-size: 12px;
     line-height: 12px;
 }
 
 .remove-icon {
-    color: #ccc;
+    color: #aaa;
     padding-top: 8px;
     float: right;
     opacity: 0;
-    font-size: 16px;
     line-height: 12px;
     cursor: pointer;
+    
+    margin-left: 5px;
+    font-size: 12px;
 }
 
 .empty {

--- a/src/component/form/CaseElement.tsx
+++ b/src/component/form/CaseElement.tsx
@@ -460,11 +460,7 @@ export default class CaseElement extends React.Component<CaseElementProps, CaseE
 
     private getDndIco(): JSX.Element {
         if (!this.props.empty && !this.props.solo) {
-            return (
-                <div className={styles.dndIcon}>
-                    <span>&#8597;</span>
-                </div>
-            );
+            return <span className={`fe-chevrons-expand ${styles.dndIcon}`} />;
         }
 
         return <div className={styles.empty} />;
@@ -472,7 +468,7 @@ export default class CaseElement extends React.Component<CaseElementProps, CaseE
 
     private getRemoveIco(): JSX.Element {
         if (!this.props.empty) {
-            return <span className={`fe-remove ${styles.removeIcon}`} onClick={this.onRemove} />;
+            return <span className={`fe-x ${styles.removeIcon}`} onClick={this.onRemove} />;
         }
 
         return null;

--- a/src/component/routers/GroupsRouter.test.tsx
+++ b/src/component/routers/GroupsRouter.test.tsx
@@ -20,13 +20,11 @@ const sendMsgNode = createFlowNode({
 
 const baseProps: GroupsRouterProps = {
     translating: false,
-    localGroups: [],
-    nodeToEdit: groupsRouterNode,
+    settings: { originalNode: groupsRouterNode },
     saveLocalizations: jest.fn(),
     updateRouter: jest.fn(),
     getExitTranslations: jest.fn(),
-    getResultNameField: jest.fn(),
-    onBindWidget: jest.fn()
+    getResultNameField: jest.fn()
 };
 
 const { setup } = composeComponentTestUtils(GroupsRouter, baseProps);

--- a/src/component/routers/GroupsRouter.tsx
+++ b/src/component/routers/GroupsRouter.tsx
@@ -14,11 +14,12 @@ import { GetResultNameField } from '../NodeEditor';
 import { hasSwitchRouter, SaveLocalizations } from '../NodeEditor/NodeEditor';
 import { GROUP_LABEL } from './constants';
 import * as styles from './SwitchRouter.scss';
+import { NodeEditorSettings } from '../../store/nodeEditor';
 
 // import { endpointsPT } from '../../config';
 export interface GroupsRouterStoreProps {
     translating: boolean;
-    nodeToEdit: FlowNode;
+    settings: NodeEditorSettings;
 }
 
 export interface GroupsRouterPassedProps {
@@ -99,8 +100,8 @@ export class GroupsRouter extends React.Component<GroupsRouterProps, TempGroupSt
         }
 
         const groupProps: Partial<GroupsElementProps> = {};
-        if (hasGroupsRouter(this.props.nodeToEdit)) {
-            groupProps.entry = { value: extractGroups(this.props.nodeToEdit) };
+        if (hasGroupsRouter(this.props.settings.originalNode)) {
+            groupProps.entry = { value: extractGroups(this.props.settings.originalNode) };
         }
 
         const nameField: JSX.Element = this.props.getResultNameField();
@@ -125,10 +126,10 @@ export class GroupsRouter extends React.Component<GroupsRouterProps, TempGroupSt
 
 const mapStateToProps = ({
     flowEditor: { editorUI: { translating } },
-    nodeEditor: { nodeToEdit }
+    nodeEditor: { settings }
 }: AppState) => ({
     translating,
-    nodeToEdit
+    settings
 });
 
 const ConnectedGroupsRouterForm = connect(mapStateToProps, null, null, { withRef: true })(

--- a/src/component/routers/SwitchRouter.test.tsx
+++ b/src/component/routers/SwitchRouter.test.tsx
@@ -27,7 +27,7 @@ import {
     InputToFocus,
     leadInSpecId,
     SwitchRouterForm,
-    SwitchRouterFormProps,
+    SwitchRouterFormProps
 } from './SwitchRouter';
 
 jest.mock('uuid', () => ({
@@ -72,7 +72,7 @@ const baseProps: SwitchRouterFormProps = {
     language: { iso: 'eng', name: 'English' },
     typeConfig: getTypeConfig(Types.wait_for_response),
     translating: false,
-    nodeToEdit,
+    settings: { originalNode: nodeToEdit },
     localizations: [],
     operand: DEFAULT_OPERAND,
     showAdvanced: false,
@@ -226,7 +226,9 @@ describe(SwitchRouterForm.name, () => {
         describe('getCaseContext', () => {
             it('should return unwrapped, empty case', () => {
                 const { wrapper, props } = setup(true, {
-                    nodeToEdit: { router: { $merge: { cases: [] } } }
+                    settings: {
+                        originalNode: { router: { $merge: { cases: [] } } }
+                    }
                 });
 
                 expect(getSpecWrapper(wrapper, leadInSpecId).exists()).toBeTruthy();
@@ -260,10 +262,12 @@ describe(SwitchRouterForm.name, () => {
 
             it('should add an undraggable, displayable case', () => {
                 const { wrapper } = setup(true, {
-                    nodeToEdit: {
-                        router: {
-                            $merge: {
-                                cases: [cases[0]]
+                    settings: {
+                        originalNode: {
+                            router: {
+                                $merge: {
+                                    cases: [cases[0]]
+                                }
                             }
                         }
                     }
@@ -384,7 +388,8 @@ describe(SwitchRouterForm.name, () => {
                 const { wrapper, instance, props } = setup(true, {
                     removeWidget: setMock()
                 });
-                const { uuid: caseUUID } = (props.nodeToEdit.router as SwitchRouter).cases[0];
+                const { uuid: caseUUID } = (props.settings.originalNode
+                    .router as SwitchRouter).cases[0];
                 const caseToRemove = {
                     props: {
                         name: `case_${caseUUID}`,

--- a/src/component/routers/SwitchRouter.tsx
+++ b/src/component/routers/SwitchRouter.tsx
@@ -3,7 +3,13 @@
 import { react as bindCallbacks } from 'auto-bind';
 import update from 'immutability-helper';
 import * as React from 'react';
-import { DragDropContext, Draggable, DraggableStyle, Droppable, DropResult } from 'react-beautiful-dnd';
+import {
+    DragDropContext,
+    Draggable,
+    DraggableStyle,
+    Droppable,
+    DropResult
+} from 'react-beautiful-dnd';
 import { connect } from 'react-redux';
 import { v4 as generateUUID } from 'uuid';
 
@@ -21,6 +27,7 @@ import { GetResultNameField } from '../NodeEditor';
 import { hasCases, SaveLocalizations } from '../NodeEditor/NodeEditor';
 import { EXPRESSION_LABEL, OPERAND_LOCALIZATION_DESC, WAIT_LABEL } from './constants';
 import * as styles from './SwitchRouter.scss';
+import { NodeEditorSettings } from '../../store/nodeEditor';
 
 export enum DragCursor {
     move = 'move',
@@ -38,7 +45,7 @@ export interface SwitchRouterStoreProps {
     language: Asset;
     typeConfig: Type;
     translating: boolean;
-    nodeToEdit: FlowNode;
+    settings: NodeEditorSettings;
     localizations: LocalizedObject[];
     operand: string;
 }
@@ -247,11 +254,11 @@ export class SwitchRouterForm extends React.Component<SwitchRouterFormProps, Swi
     private getInitialState(): SwitchRouterState {
         const displayableCases = [];
 
-        const router = this.props.nodeToEdit.router as SwitchRouter;
+        const router = this.props.settings.originalNode.router as SwitchRouter;
 
-        if (router && hasCases(this.props.nodeToEdit)) {
+        if (router && hasCases(this.props.settings.originalNode)) {
             const existingCases = casePropsFromNode({
-                nodeToEdit: this.props.nodeToEdit,
+                nodeToEdit: this.props.settings.originalNode,
                 handleCaseChanged: this.handleCaseChanged,
                 handleCaseRemoved: this.handleCaseRemoved
             });
@@ -413,7 +420,7 @@ export class SwitchRouterForm extends React.Component<SwitchRouterFormProps, Swi
     }
 
     public getCasesForLocalization(): JSX.Element[] {
-        return (this.props.nodeToEdit.router as SwitchRouter).cases.reduce(
+        return (this.props.settings.originalNode.router as SwitchRouter).cases.reduce(
             (casesForLocalization: JSX.Element[], kase) => {
                 // only allow translations for cases with arguments that aren't numeric
                 if (kase.arguments && kase.arguments.length > 0 && !/number/.test(kase.type)) {
@@ -483,7 +490,7 @@ export class SwitchRouterForm extends React.Component<SwitchRouterFormProps, Swi
                     <p>{EXPRESSION_LABEL}</p>
                     <TextInputElement
                         ref={this.props.onBindWidget}
-                        key={this.props.nodeToEdit.uuid}
+                        key={this.props.settings.originalNode.uuid}
                         name="Expression"
                         showLabel={false}
                         entry={{ value: this.props.operand }}
@@ -575,8 +582,8 @@ export class SwitchRouterForm extends React.Component<SwitchRouterFormProps, Swi
 const mapStateToProps = ({
     flowContext: { localizations },
     flowEditor: { editorUI: { language, translating } },
-    nodeEditor: { typeConfig, nodeToEdit, operand }
-}: AppState) => ({ language, typeConfig, translating, nodeToEdit, localizations, operand });
+    nodeEditor: { typeConfig, settings, operand }
+}: AppState) => ({ language, typeConfig, translating, settings, localizations, operand });
 
 const ConnectedSwitchRouterForm = connect(mapStateToProps, null, null, { withRef: true })(
     SwitchRouterForm

--- a/src/store/actionTypes.ts
+++ b/src/store/actionTypes.ts
@@ -207,16 +207,6 @@ export type UpdatePendingConnectionAction = DuxAction<
     UpdatePendingConnectionPayload
 >;
 
-export type UpdateActionToEditAction = DuxAction<
-    Constants.UPDATE_ACTION_TO_EDIT,
-    UpdateActionToEditPayload
->;
-
-export type UpdateNodeToEditAction = DuxAction<
-    Constants.UPDATE_NODE_TO_EDIT,
-    UpdateNodeToEditPayload
->;
-
 export type UpdateLocalizationsAction = DuxAction<
     Constants.UPDATE_LOCALIZATIONS,
     UpdateLocalizationsPayload
@@ -303,8 +293,6 @@ type ActionTypes =
     | UpdateGhostNodeAction
     | UpdateCreateNodePositionAction
     | UpdatePendingConnectionAction
-    | UpdateActionToEditAction
-    | UpdateNodeToEditAction
     | UpdateLocalizationsAction
     | UpdateDragGroupAction
     | UpdateTypeConfigAction

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -29,7 +29,6 @@ import {
     updateTranslating
 } from './flowEditor';
 import {
-    updateActionToEdit,
     updateForm,
     updateOperand,
     updateResultName,
@@ -119,7 +118,6 @@ export {
     updateNodeEditorOpen,
     updateGhostNode,
     updateCreateNodePosition,
-    updateActionToEdit,
     fetchFlow,
     FetchFlow,
     ensureStartNode,

--- a/src/store/nodeEditor.test.ts
+++ b/src/store/nodeEditor.test.ts
@@ -2,16 +2,12 @@ import { getTypeConfig } from '../config';
 import { Types } from '../config/typeConfigs';
 import Constants from './constants';
 import reducer, {
-    actionToEdit as actionToEditReducer,
     initialState,
-    nodeToEdit as nodeToEditReducer,
     operand as operandReducer,
     resultName as resultNameReducer,
     showResultName as showResultNameReducer,
     timeout as timeoutReducer,
     typeConfig as typeConfigReducer,
-    updateActionToEdit,
-    updateNodeToEdit,
     updateOperand,
     updateResultName,
     updateShowResultName,
@@ -73,32 +69,6 @@ describe('nodeEditor action creators', () => {
                 }
             };
             expect(updateUserAddingAction(userAddingAction)).toEqual(expectedAction);
-        });
-    });
-
-    describe('updateActionToEdit', () => {
-        it('should create an action to update actionToEdit state', () => {
-            const { actions: [actionToEdit] } = definition.nodes[0];
-            const expectedAction = {
-                type: Constants.UPDATE_ACTION_TO_EDIT,
-                payload: {
-                    actionToEdit
-                }
-            };
-            expect(updateActionToEdit(actionToEdit)).toEqual(expectedAction);
-        });
-    });
-
-    describe('updateNodeToEdit', () => {
-        it('should create an action to update nodeToEdit state', () => {
-            const nodeToEdit = definition.nodes[0];
-            const expectedAction = {
-                type: Constants.UPDATE_NODE_TO_EDIT,
-                payload: {
-                    nodeToEdit
-                }
-            };
-            expect(updateNodeToEdit(nodeToEdit)).toEqual(expectedAction);
         });
     });
 
@@ -197,34 +167,6 @@ describe('nodeEditor reducers', () => {
             const userAddingAction = true;
             const action = updateUserAddingAction(userAddingAction);
             expect(reduce(action)).toEqual(userAddingAction);
-        });
-    });
-
-    describe('nodeToEdit reducer', () => {
-        const reduce = action => nodeToEditReducer(undefined, action);
-
-        it('should return initial state', () => {
-            expect(reduce({})).toEqual(initialState.nodeToEdit);
-        });
-
-        it('should handle UPDATE_NODE_TO_EDIT', () => {
-            const nodeToEdit = definition.nodes[0];
-            const action = updateNodeToEdit(nodeToEdit);
-            expect(reduce(action)).toEqual(nodeToEdit);
-        });
-    });
-
-    describe('actionToEdit reducer', () => {
-        const reduce = action => actionToEditReducer(undefined, action);
-
-        it('should return initial state', () => {
-            expect(reduce({})).toEqual(initialState.actionToEdit);
-        });
-
-        it('should handle UPDATE_ACTION_TO_EDIT', () => {
-            const { actions: [actionToEdit] } = definition.nodes[0];
-            const action = updateActionToEdit(actionToEdit);
-            expect(reduce(action)).toEqual(actionToEdit);
         });
     });
 

--- a/src/store/nodeEditor.ts
+++ b/src/store/nodeEditor.ts
@@ -6,16 +6,14 @@ import { Types } from '../config/typeConfigs';
 import { AnyAction, FlowNode } from '../flowTypes';
 import { Asset } from '../services/AssetService';
 import ActionTypes, {
-    UpdateActionToEditAction,
     UpdateFormAction,
     UpdateNodeEditorSettings,
-    UpdateNodeToEditAction,
     UpdateOperandAction,
     UpdateResultNameAction,
     UpdateShowResultNameAction,
     UpdateTimeoutAction,
     UpdateTypeConfigAction,
-    UpdateUserAddingActionAction,
+    UpdateUserAddingActionAction
 } from './actionTypes';
 import Constants from './constants';
 
@@ -124,7 +122,9 @@ export type NodeEditorForm =
     | SendEmailFormState;
 
 export interface NodeEditorSettings {
-    showAdvanced: boolean;
+    originalNode: FlowNode;
+    showAdvanced?: boolean;
+    originalAction?: AnyAction;
 }
 
 export interface NodeEditor {
@@ -133,8 +133,6 @@ export interface NodeEditor {
     showResultName: boolean;
     operand: string;
     userAddingAction: boolean;
-    nodeToEdit: FlowNode;
-    actionToEdit: AnyAction;
     settings: NodeEditorSettings;
     form: NodeEditorForm;
     timeout: number;
@@ -149,11 +147,9 @@ export const initialState: NodeEditor = {
     showResultName: false,
     operand: DEFAULT_OPERAND,
     userAddingAction: false,
-    nodeToEdit: null,
-    actionToEdit: null,
     form: null,
     timeout: null,
-    settings: { showAdvanced: false }
+    settings: null
 };
 
 // Action Creators
@@ -200,20 +196,6 @@ export const updateUserAddingAction = (
     type: Constants.UPDATE_USER_ADDING_ACTION,
     payload: {
         userAddingAction
-    }
-});
-
-export const updateActionToEdit = (actionToEdit: AnyAction): UpdateActionToEditAction => ({
-    type: Constants.UPDATE_ACTION_TO_EDIT,
-    payload: {
-        actionToEdit
-    }
-});
-
-export const updateNodeToEdit = (nodeToEdit: FlowNode): UpdateNodeToEditAction => ({
-    type: Constants.UPDATE_NODE_TO_EDIT,
-    payload: {
-        nodeToEdit
     }
 });
 
@@ -293,24 +275,6 @@ export const userAddingAction = (
     }
 };
 
-export const nodeToEdit = (state: FlowNode = initialState.nodeToEdit, action: ActionTypes) => {
-    switch (action.type) {
-        case Constants.UPDATE_NODE_TO_EDIT:
-            return action.payload.nodeToEdit;
-        default:
-            return state;
-    }
-};
-
-export const actionToEdit = (state: AnyAction = initialState.actionToEdit, action: ActionTypes) => {
-    switch (action.type) {
-        case Constants.UPDATE_ACTION_TO_EDIT:
-            return action.payload.actionToEdit;
-        default:
-            return state;
-    }
-};
-
 export const timeout = (state: number = initialState.timeout, action: ActionTypes) => {
     switch (action.type) {
         case Constants.UPDATE_TIMEOUT:
@@ -339,8 +303,6 @@ export default combineReducers({
     showResultName,
     operand,
     userAddingAction,
-    nodeToEdit,
-    actionToEdit,
     settings,
     form,
     timeout

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -17,7 +17,7 @@ import {
     FlowPosition,
     SendMsg,
     StickyNote,
-    SwitchRouter,
+    SwitchRouter
 } from '../flowTypes';
 import AssetService, { Asset } from '../services/AssetService';
 import { NODE_SPACING, timeEnd, timeStart } from '../utils';
@@ -29,7 +29,7 @@ import {
     updateDefinition,
     updateLanguages,
     updateLocalizations,
-    updateNodes,
+    updateNodes
 } from './flowContext';
 import {
     updateCreateNodePosition,
@@ -40,7 +40,7 @@ import {
     updateNodeDragging,
     updateNodeEditorOpen,
     updatePendingConnection,
-    updateTranslating,
+    updateTranslating
 } from './flowEditor';
 import {
     determineConfigType,
@@ -49,21 +49,19 @@ import {
     getCollision,
     getFlowComponents,
     getGhostNode,
-    getLocalizations,
+    getLocalizations
 } from './helpers';
 import * as mutators from './mutators';
 import {
     NodeEditorSettings,
-    updateActionToEdit,
     updateForm,
     updateNodeEditorSettings,
-    updateNodeToEdit,
     updateOperand,
     updateResultName,
     updateShowResultName,
     updateTimeout,
     updateTypeConfig,
-    updateUserAddingAction,
+    updateUserAddingAction
 } from './nodeEditor';
 import AppState from './state';
 
@@ -83,11 +81,7 @@ export type OnResetDragSelection = () => Thunk<void>;
 
 export type OnNodeMoved = (uuid: string, position: FlowPosition) => Thunk<RenderNodeMap>;
 
-export type OnOpenNodeEditor = (
-    node: FlowNode,
-    action: AnyAction,
-    settings?: NodeEditorSettings
-) => Thunk<void>;
+export type OnOpenNodeEditor = (settings: NodeEditorSettings) => Thunk<void>;
 
 export type RemoveNode = (nodeToRemove: FlowNode) => Thunk<RenderNodeMap>;
 
@@ -499,10 +493,7 @@ export const handleTypeConfigChange = (typeConfig: Type, actionToEdit: AnyAction
 };
 
 export const resetNodeEditingState = () => (dispatch: DispatchWithState, getState: GetState) => {
-    const {
-        flowEditor: { flowUI: { pendingConnection, createNodePosition } },
-        nodeEditor: { actionToEdit, nodeToEdit }
-    } = getState();
+    const { flowEditor: { flowUI: { pendingConnection, createNodePosition } } } = getState();
 
     dispatch(updateGhostNode(null));
 
@@ -514,16 +505,8 @@ export const resetNodeEditingState = () => (dispatch: DispatchWithState, getStat
         dispatch(updateCreateNodePosition(null));
     }
 
-    if (actionToEdit) {
-        dispatch(updateActionToEdit(null));
-    }
-
-    if (nodeToEdit) {
-        dispatch(updateNodeToEdit(null));
-    }
-
+    dispatch(updateNodeEditorSettings(null));
     dispatch(updateForm(null));
-    dispatch(updateNodeEditorSettings({ showAdvanced: false }));
     dispatch(updateTimeout(null));
 };
 
@@ -535,16 +518,17 @@ export const onUpdateAction = (action: AnyAction) => (
 
     const {
         flowEditor: { flowUI: { pendingConnection, createNodePosition } },
-        nodeEditor: { userAddingAction, nodeToEdit },
+        nodeEditor: { userAddingAction, settings },
         flowContext: { nodes }
     } = getState();
 
-    if (nodeToEdit == null) {
-        throw new Error('Need nodeToEdit in state to update an action');
+    if (settings == null || settings.originalNode == null) {
+        throw new Error('Need originalNode in settings to update an action');
     }
+    const { originalNode } = settings;
 
     let updatedNodes = nodes;
-    const creatingNewNode = pendingConnection && pendingConnection.nodeUUID !== nodeToEdit.uuid;
+    const creatingNewNode = pendingConnection && pendingConnection.nodeUUID !== originalNode.uuid;
 
     if (creatingNewNode) {
         const newNode: RenderNode = {
@@ -559,9 +543,9 @@ export const onUpdateAction = (action: AnyAction) => (
 
         updatedNodes = mutators.mergeNode(nodes, newNode);
     } else if (userAddingAction) {
-        updatedNodes = mutators.addAction(nodes, nodeToEdit.uuid, action);
+        updatedNodes = mutators.addAction(nodes, originalNode.uuid, action);
     } else {
-        updatedNodes = mutators.updateAction(nodes, nodeToEdit.uuid, action);
+        updatedNodes = mutators.updateAction(nodes, originalNode.uuid, action);
     }
 
     timeEnd('onUpdateAction');
@@ -588,8 +572,13 @@ export const onAddToNode = (node: FlowNode) => (
     };
 
     dispatch(updateUserAddingAction(true));
-    dispatch(updateActionToEdit(newAction));
-    dispatch(updateNodeToEdit(node));
+    dispatch(
+        updateNodeEditorSettings({
+            originalNode: node,
+            originalAction: newAction,
+            showAdvanced: false
+        })
+    );
     dispatch(updateLocalizations([]));
     dispatch(handleTypeConfigChange(getTypeConfig(Types.send_msg)));
     dispatch(updateNodeDragging(false));
@@ -689,20 +678,17 @@ export const onUpdateRouter = (node: RenderNode) => (
     const {
         flowContext: { nodes },
         flowEditor: { flowUI: { pendingConnection, createNodePosition } },
-        nodeEditor: { nodeToEdit, actionToEdit }
+        nodeEditor: { settings: { originalNode, originalAction } }
     } = getState();
 
-    const previousNode = nodes[nodeToEdit.uuid];
+    const previousNode = nodes[originalNode.uuid];
 
     let updated = nodes;
     if (createNodePosition) {
         node.ui.position = createNodePosition;
     } else {
         const previousPosition = previousNode.ui.position;
-        node.ui.position = {
-            left: previousPosition.left,
-            top: previousPosition.top
-        };
+        node.ui.position = previousPosition;
     }
 
     if (pendingConnection) {
@@ -710,9 +696,13 @@ export const onUpdateRouter = (node: RenderNode) => (
         node.node = mutators.uniquifyNode(node.node);
     }
 
-    if (nodeToEdit && actionToEdit && previousNode) {
+    console.log('-------------------------------------------');
+    console.log(originalNode);
+    console.log(originalAction);
+
+    if (originalNode && originalAction && previousNode) {
         const actionToSplice = previousNode.node.actions.find(
-            (action: Action) => action.uuid === actionToEdit.uuid
+            (action: Action) => action.uuid === originalAction.uuid
         );
 
         if (actionToSplice) {
@@ -764,19 +754,20 @@ const markReflow = (dispatch: DispatchWithState) => {
     );
 };
 
-export const onOpenNodeEditor = (
-    node: FlowNode,
-    action: AnyAction,
-    settings: NodeEditorSettings
-) => (dispatch: DispatchWithState, getState: GetState) => {
+export const onOpenNodeEditor = (settings: NodeEditorSettings) => (
+    dispatch: DispatchWithState,
+    getState: GetState
+) => {
     const {
         flowContext: { baseLanguage, nodes, definition: { localization } },
         flowEditor: { editorUI: { language, translating } },
         nodeEditor: { settings: currentSettings }
     } = getState();
 
-    const localizations = [];
+    const node = settings.originalNode;
+    let action = settings.originalAction;
 
+    const localizations = [];
     if (translating) {
         let actionToTranslate = action;
 
@@ -794,17 +785,26 @@ export const onOpenNodeEditor = (
         localizations.push(...getLocalizations(node, actionToTranslate, language, translations));
     }
 
-    if (action) {
-        dispatch(updateActionToEdit(action));
-    } else if (node.actions.length > 0) {
-        // Account for hybrids or clicking on the empty exit table
-        dispatch(updateActionToEdit(node.actions[node.actions.length - 1]));
+    // Account for hybrids or clicking on the empty exit table
+    if (!action && node.actions.length > 0) {
+        action = node.actions[node.actions.length - 1];
     }
 
     const type = determineConfigType(node, action, nodes);
     const typeConfig = getTypeConfig(type);
 
-    if (typeConfig.formHelper) {
+    let toEdit = action;
+    if (translating) {
+        if (localizations && localizations.length === 1 && localizations[0].isLocalized()) {
+            toEdit = localizations[0].getObject() as AnyAction;
+        } else {
+            toEdit = null;
+        }
+    }
+
+    dispatch(handleTypeConfigChange(typeConfig, toEdit));
+
+    /* if (typeConfig.formHelper) {
         let toEdit = action;
         if (translating) {
             if (localizations && localizations.length === 1 && localizations[0].isLocalized()) {
@@ -816,6 +816,7 @@ export const onOpenNodeEditor = (
         dispatch(updateForm(typeConfig.formHelper.actionToState(toEdit, typeConfig.type)));
     }
     dispatch(updateTypeConfig(getTypeConfig(type as Types)));
+    */
 
     let resultName = '';
 
@@ -844,7 +845,6 @@ export const onOpenNodeEditor = (
     }
 
     dispatch(updateNodeDragging(false));
-    dispatch(updateNodeToEdit(node));
     dispatch(updateLocalizations(localizations));
     dispatch(updateResultName(resultName));
     dispatch(updateShowResultName(resultName.length > 0));


### PR DESCRIPTION
This is mostly housekeeping to prepare for a uniform form model for nodes and actions. It pretty much is just moving `nodeToEdit` and `actionToEdit` to be part of `NodeEditorSettings`. The goal being that the bits needed to construct the forms (on load and type change but are otherwise static) will live there. Also removes associated redux actions and reducers.

Current thinking is that eventually `nodeEditor` will be comprised of `settings` and `form`. The remaining things will be pushed into one or the other.