### PR TITLE
Fix #343

### DIFF
--- a/src/component/actions/SetContactAttrib/SetContactAttribFormHelper.test.ts
+++ b/src/component/actions/SetContactAttrib/SetContactAttribFormHelper.test.ts
@@ -2,20 +2,19 @@ import { Types } from '../../../config/typeConfigs';
 import { Channel, SetContactChannel } from '../../../flowTypes';
 import { AssetType, removeAsset } from '../../../services/AssetService';
 import {
+    createSendMsgAction,
     createSetContactChannelAction,
     createSetContactFieldAction,
     createSetContactLanguageAction,
-    createSetContactNameAction
+    createSetContactNameAction,
 } from '../../../testUtils/assetCreators';
 import { getLanguage } from '../../../utils/languageMap';
 import { languageToAsset } from './helpers';
-import {
-    SetContactAttribFormHelper,
-    SetContactAttribFormHelperActionTypes
-} from './SetContactAttribFormHelper';
+import { SetContactAttribFormHelper, SetContactAttribFormHelperActionTypes } from './SetContactAttribFormHelper';
 
 const formHelper = new SetContactAttribFormHelper();
 
+const sendMsgAction = createSendMsgAction();
 const setContactFieldAction = createSetContactFieldAction();
 const setContactNameAction = createSetContactNameAction();
 const setContactLanguageAction = createSetContactLanguageAction();

--- a/src/component/actions/SetContactAttrib/SetContactAttribFormHelper.ts
+++ b/src/component/actions/SetContactAttrib/SetContactAttribFormHelper.ts
@@ -34,7 +34,7 @@ export class SetContactAttribFormHelper implements FormHelper {
         let formState: SetContactAttribFormState;
 
         // if we have an existing contact attribute action, use it
-        if (settings && settings.originalAction) {
+        if (settings.originalAction) {
             const action = settings.originalAction as SetContactAttribute;
             switch (action.type) {
                 case Types.set_contact_field:

--- a/src/component/actions/SetContactAttrib/SetContactAttribFormHelper.ts
+++ b/src/component/actions/SetContactAttrib/SetContactAttribFormHelper.ts
@@ -5,25 +5,19 @@ import {
     SetContactChannel,
     SetContactField,
     SetContactLanguage,
-    SetContactName
+    SetContactName,
 } from '../../../flowTypes';
 import { removeAsset } from '../../../services/AssetService';
 import {
+    NodeEditorSettings,
     SetContactAttribFormState,
     SetContactChannelFormState,
     SetContactFieldFormState,
     SetContactLanguageFormState,
     SetContactNameFormState,
-    NodeEditorSettings
 } from '../../../store/nodeEditor';
 import { getLanguage } from '../../../utils/languageMap';
-import {
-    assetToField,
-    channelToAsset,
-    fieldToAsset,
-    languageToAsset,
-    propertyToAsset
-} from './helpers';
+import { assetToField, channelToAsset, fieldToAsset, languageToAsset, propertyToAsset } from './helpers';
 
 export type SetContactAttribFormHelperActionTypes =
     | Types.set_contact_field
@@ -40,7 +34,7 @@ export class SetContactAttribFormHelper implements FormHelper {
         let formState: SetContactAttribFormState;
 
         // if we have an existing contact attribute action, use it
-        if (settings.originalAction) {
+        if (settings && settings.originalAction) {
             const action = settings.originalAction as SetContactAttribute;
             switch (action.type) {
                 case Types.set_contact_field:

--- a/src/component/form/AttribElement.test.tsx
+++ b/src/component/form/AttribElement.test.tsx
@@ -2,7 +2,7 @@ import { getTypeConfig } from '../../config';
 import { Types } from '../../config/typeConfigs';
 import { Asset, AssetType } from '../../services/AssetService';
 import { composeComponentTestUtils, configProviderContext, setMock } from '../../testUtils';
-import { createSetContactFieldAction } from '../../testUtils/assetCreators';
+import { createExit, createSendMsgAction, createSetContactFieldAction } from '../../testUtils/assetCreators';
 import { isOptionUnique, isValidNewOption } from '../../utils';
 import { fieldToAsset, propertyToAsset } from '../actions/SetContactAttrib/helpers';
 import { AttribElement, AttribElementProps, CREATE_PROMPT, createNewOption } from './AttribElement';
@@ -13,11 +13,20 @@ const attribute: Asset = {
     type: AssetType.Name
 };
 
+const originalAction = createSendMsgAction();
+
+const originalNode = {
+    uuid: 'original-node-0',
+    actions: [originalAction],
+    exits: [createExit()]
+};
+
 const baseProps: AttribElementProps = {
     name: 'Attribute',
     attribute: { value: attribute },
     typeConfig: getTypeConfig(Types.set_contact_name),
     assets: configProviderContext.assetService.getFieldAssets(),
+    settings: { originalAction, originalNode },
     handleTypeConfigChange: jest.fn(),
     onChange: jest.fn()
 };
@@ -68,7 +77,7 @@ describe(AttribElement.name, () => {
                 expect(props.handleTypeConfigChange).toHaveBeenCalledTimes(1);
                 expect(props.handleTypeConfigChange).toHaveBeenCalledWith(
                     getTypeConfig(Types.set_contact_name),
-                    null
+                    props.settings
                 );
             });
 
@@ -87,7 +96,7 @@ describe(AttribElement.name, () => {
                 expect(props.handleTypeConfigChange).toHaveBeenCalledTimes(1);
                 expect(props.handleTypeConfigChange).toHaveBeenCalledWith(
                     getTypeConfig(Types.set_contact_field),
-                    null
+                    props.settings
                 );
             });
 
@@ -113,7 +122,7 @@ describe(AttribElement.name, () => {
                 expect(props.handleTypeConfigChange).toHaveBeenCalledTimes(1);
                 expect(props.handleTypeConfigChange).toHaveBeenCalledWith(
                     getTypeConfig(Types.set_contact_name),
-                    null
+                    props.settings
                 );
             });
         });

--- a/src/component/form/AttribElement.tsx
+++ b/src/component/form/AttribElement.tsx
@@ -8,6 +8,7 @@ import { Asset, Assets, AssetType } from '../../services/AssetService';
 import { AppState, DispatchWithState, HandleTypeConfigChange, handleTypeConfigChange } from '../../store';
 import {
     AssetEntry,
+    NodeEditorSettings,
     SetContactAttribFormState,
     SetContactChannelFormState,
     SetContactFieldFormState,
@@ -30,6 +31,7 @@ export interface AttribElementPassedProps extends FormElementProps {
 
 export interface AttribElementStoreProps {
     attribute: AssetEntry;
+    settings: NodeEditorSettings;
     handleTypeConfigChange: HandleTypeConfigChange;
 }
 
@@ -81,7 +83,7 @@ export class AttribElement extends React.Component<AttribElementProps> {
         const [attribute] = selected;
         const nextConfig = getNextConfig(attribute.type);
 
-        this.props.handleTypeConfigChange(nextConfig, null);
+        this.props.handleTypeConfigChange(nextConfig, this.props.settings);
 
         if (this.props.onChange) {
             this.props.onChange(attribute);
@@ -131,8 +133,9 @@ const selectAttribute = (form: SetContactAttribFormState) =>
     (form as SetContactChannelFormState).channel;
 
 /* istanbul ignore next */
-const mapStateToProps = ({ nodeEditor: { form } }: AppState) => ({
-    attribute: selectAttribute(form as SetContactAttribFormState)
+const mapStateToProps = ({ nodeEditor: { form, settings } }: AppState) => ({
+    attribute: selectAttribute(form as SetContactAttribFormState),
+    settings
 });
 
 /* istanbul ignore next */

--- a/src/store/mutators.test.ts
+++ b/src/store/mutators.test.ts
@@ -1,22 +1,20 @@
+import { Types } from '../config/typeConfigs';
+import { FlowDefinition, SendMsg } from '../flowTypes';
+import { createSendMsgAction } from '../testUtils/assetCreators';
+import { getActionIndex, getExitIndex, getFlowComponents, getNode } from './helpers';
 import {
-    updateConnection,
-    removeConnection,
-    mergeNode,
     addAction,
-    updateAction,
-    removeAction,
+    mergeNode,
     moveActionUp,
-    removeNode,
-    updatePosition,
+    removeAction,
+    removeConnection,
+    removeNodeAndRemap,
+    updateAction,
+    updateConnection,
     updateDimensions,
     updateLocalization,
-    removeNodeAndRemap
+    updatePosition,
 } from './mutators';
-import { RenderNodeMap } from './flowContext';
-import { SendMsg, FlowDefinition, FlowNode } from '../flowTypes';
-import { dump } from '../utils';
-import { getNode, getExitIndex, getActionIndex, getFlowComponents } from './helpers';
-import { Types } from '../config/typeConfigs';
 
 describe('mutators', () => {
     const definition: FlowDefinition = require('../../__test__/flows/boring.json');
@@ -92,28 +90,22 @@ describe('mutators', () => {
     });
 
     describe('updateAction()', () => {
-        it("should throw if trying to update an action that doesn't exist", () => {
-            expect(() => {
-                updateAction(nodes, 'node0', {
-                    uuid: 'missing-action',
-                    type: Types.send_msg,
-                    text: 'Hello World'
-                } as SendMsg);
-            }).toThrowError('Cannot find action missing-action');
-        });
-
         it('should update an action that was added', () => {
-            let updated = addAction(nodes, 'node0', {
+            const originalAction = {
                 uuid: 'node0_action3',
                 type: Types.send_msg,
                 text: 'Hello World'
-            } as SendMsg);
+            } as SendMsg;
 
-            updated = updateAction(updated, 'node0', {
+            const newAction = {
                 uuid: 'node0_action3',
                 type: Types.send_msg,
                 text: 'Goodbye World'
-            } as SendMsg);
+            } as SendMsg;
+
+            let updated = addAction(nodes, 'node0', originalAction);
+
+            updated = updateAction(updated, 'node0', newAction, originalAction);
 
             // we added one to get to four and then edited it
             expect(updated.node0.node.actions.length).toBe(5);
@@ -122,6 +114,19 @@ describe('mutators', () => {
             expect(action.type).toBe(Types.send_msg);
             expect(action.text).toBe('Goodbye World');
             expect(updated).toMatchSnapshot();
+        });
+
+        it('should add the updated action at the index of the original action', () => {
+            const indexToUpdate = 1;
+            const newAction = createSendMsgAction();
+            const updated = updateAction(
+                nodes,
+                'node0',
+                newAction,
+                nodes.node0.node.actions[indexToUpdate]
+            );
+
+            expect(updated.node0.node.actions[indexToUpdate]).toEqual(newAction);
         });
     });
 

--- a/src/store/mutators.ts
+++ b/src/store/mutators.ts
@@ -152,14 +152,19 @@ export const addAction = (
  * @param nodeUUID
  * @param action
  */
-export const updateAction = (nodes: RenderNodeMap, nodeUUID: string, action: AnyAction) => {
+export const updateAction = (
+    nodes: RenderNodeMap,
+    nodeUUID: string,
+    newAction: AnyAction,
+    originalAction?: AnyAction
+) => {
     const nodeToEdit = getNode(nodes, nodeUUID);
     // If we have existing actions, find our action and update it
-    const actionIdx = getActionIndex(nodeToEdit.node, action.uuid);
+    const actionIdx = originalAction ? getActionIndex(nodeToEdit.node, originalAction.uuid) : 0;
     return mutate(nodes, {
         [nodeUUID]: {
             node: {
-                actions: { [actionIdx]: set(action) }
+                actions: { [actionIdx]: set(newAction) }
             }
         }
     });

--- a/src/store/mutators.ts
+++ b/src/store/mutators.ts
@@ -158,9 +158,9 @@ export const updateAction = (
     newAction: AnyAction,
     originalAction?: AnyAction
 ) => {
-    const nodeToEdit = getNode(nodes, nodeUUID);
+    const originalNode = getNode(nodes, nodeUUID);
     // If we have existing actions, find our action and update it
-    const actionIdx = originalAction ? getActionIndex(nodeToEdit.node, originalAction.uuid) : 0;
+    const actionIdx = originalAction ? getActionIndex(originalNode.node, originalAction.uuid) : 0;
     return mutate(nodes, {
         [nodeUUID]: {
             node: {

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -526,13 +526,11 @@ export const handleTypeConfigChange = (typeConfig: Type, settings: NodeEditorSet
     // now update our form accordingly
     if (typeConfig.formHelper) {
         // only use the original action if it is the same type
-        if (settings) {
-            settings.originalAction =
-                settings.originalAction && settings.originalAction.type === typeConfig.type
-                    ? settings.originalAction
-                    : null;
-        }
-        dispatch(updateForm(typeConfig.formHelper.initializeForm(settings, typeConfig.type)));
+        const customSettings =
+            settings.originalAction && settings.originalAction.type === typeConfig.type
+                ? settings
+                : { ...settings, originalAction: null };
+        dispatch(updateForm(typeConfig.formHelper.initializeForm(customSettings, typeConfig.type)));
     }
 };
 

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -569,7 +569,7 @@ export const onUpdateAction = (action: AnyAction) => (
     if (settings == null || settings.originalNode == null) {
         throw new Error('Need originalNode in settings to update an action');
     }
-    const { originalNode } = settings;
+    const { originalNode, originalAction } = settings;
 
     let updatedNodes = nodes;
     const creatingNewNode = pendingConnection && pendingConnection.nodeUUID !== originalNode.uuid;
@@ -590,7 +590,7 @@ export const onUpdateAction = (action: AnyAction) => (
     } else if (originalNode.hasOwnProperty('router')) {
         updatedNodes = mutators.spliceInAction(nodes, originalNode.uuid, action);
     } else {
-        updatedNodes = mutators.updateAction(nodes, originalNode.uuid, action);
+        updatedNodes = mutators.updateAction(nodes, originalNode.uuid, action, originalAction);
     }
 
     timeEnd('onUpdateAction');


### PR DESCRIPTION
Resolves #343 and another issue I ran into whereby `getActionIndex` is passed the `uuid` of the new action, which doesn't yet exist. You can reproduce by clicking on the first action, changing it to another action type and saving it. 

Need this for #104. 