### PR TITLE
Debug Options

### DIFF
--- a/preview/config.js
+++ b/preview/config.js
@@ -1,4 +1,5 @@
 const config = {
+    debug: true,
     flow: 'a4f64f1b-85bc-477e-b706-de313a022979'
 };
 

--- a/src/components/flow/Flow.tsx
+++ b/src/components/flow/Flow.tsx
@@ -35,6 +35,7 @@ import {
     updateSticky,
     UpdateSticky
 } from '~/store/thunks';
+import { contextTypes } from '~/testUtils';
 import {
     createUUID,
     isRealValue,
@@ -44,6 +45,7 @@ import {
     timeEnd,
     timeStart
 } from '~/utils';
+import Debug from '~/utils/debug';
 
 export interface FlowStoreProps {
     editorState: Partial<EditorState>;
@@ -100,7 +102,8 @@ export class Flow extends React.Component<FlowStoreProps, {}> {
     private ghost: any;
 
     public static contextTypes = {
-        endpoints: fakePropType
+        endpoints: fakePropType,
+        debug: fakePropType
     };
 
     constructor(props: FlowStoreProps, context: ConfigProviderContext) {
@@ -111,6 +114,10 @@ export class Flow extends React.Component<FlowStoreProps, {}> {
         this.Activity = new ActivityManager(this.props.definition.uuid, getActivity);
 
         this.Plumber = new Plumber();
+        // our debug access
+        if (context.debug) {
+            window.fe = new Debug(props, this.props.editorState.debug);
+        }
 
         bindCallbacks(this, {
             include: [/Ref$/, /^on/, /^is/]

--- a/src/components/flow/Flow.tsx
+++ b/src/components/flow/Flow.tsx
@@ -114,7 +114,8 @@ export class Flow extends React.Component<FlowStoreProps, {}> {
         this.Activity = new ActivityManager(this.props.definition.uuid, getActivity);
 
         this.Plumber = new Plumber();
-        // our debug access
+
+        /* istanbul ignore next */
         if (context.debug) {
             window.fe = new Debug(props, this.props.editorState.debug);
         }

--- a/src/components/flow/node/Node.scss
+++ b/src/components/flow/node/Node.scss
@@ -6,6 +6,25 @@
     position: absolute;
     transition: top 200ms ease-out;
 
+    .uuid {
+        user-select: text;
+        position: absolute;
+        z-index: 10000;
+        white-space: nowrap;
+        background: #ffffffDD;
+        padding: 3px;
+        border-radius: 3px;
+        cursor: pointer;
+        top: 17px;
+        align-content: center;
+        font-size: 8px;
+        font-family: monospace;
+        left: 16px;
+        &:hover {
+            background: #ffffffFF;
+        }
+    }
+
     &.dragging {
         z-index: $z_dragging;
         transition: none;

--- a/src/components/flow/node/Node.tsx
+++ b/src/components/flow/node/Node.tsx
@@ -98,7 +98,7 @@ export class NodeComp extends React.Component<NodeProps, NodeState> {
         this.state = { thisNodeDragging: false };
 
         bindCallbacks(this, {
-            include: [/Ref$/, /^on/, /^get/]
+            include: [/Ref$/, /^on/, /^get/, /^handle/]
         });
 
         this.events = createClickHandler(this.onClick);
@@ -192,6 +192,18 @@ export class NodeComp extends React.Component<NodeProps, NodeState> {
 
     public componentWillUnmount(): void {
         this.props.plumberRemove(this.props.renderNode.node.uuid);
+    }
+
+    /* istanbul ignore next */
+    private handleUUIDClicked(event: React.MouseEvent<HTMLDivElement>): void {
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(event.currentTarget);
+        selection.removeAllRanges();
+        selection.addRange(range);
+        document.execCommand('copy');
+        selection.removeAllRanges();
+        console.log(event.currentTarget.textContent + ' copied to clipboard.');
     }
 
     private onMouseOver(): void {
@@ -321,6 +333,23 @@ export class NodeComp extends React.Component<NodeProps, NodeState> {
         return false;
     }
 
+    /* istanbul ignore next */
+    private renderDebug(): JSX.Element {
+        if (this.props.editorState.debug) {
+            if (this.props.editorState.debug.showUUIDs) {
+                return (
+                    <span
+                        id={`uuid-${this.props.renderNode.node.uuid}`}
+                        onClick={this.handleUUIDClicked}
+                        className={styles.uuid}
+                    >
+                        {this.props.renderNode.node.uuid}
+                    </span>
+                );
+            }
+        }
+    }
+
     public render(): JSX.Element {
         const actions: JSX.Element[] = [];
 
@@ -445,6 +474,8 @@ export class NodeComp extends React.Component<NodeProps, NodeState> {
             top: this.props.renderNode.ui.position.top
         };
 
+        const uuid: JSX.Element = this.renderDebug();
+
         return (
             <div
                 style={style}
@@ -453,6 +484,8 @@ export class NodeComp extends React.Component<NodeProps, NodeState> {
                 ref={this.eleRef}
             >
                 <div className={styles.node}>
+                    {uuid}
+
                     <CounterComp
                         ref={this.props.Activity.registerListener}
                         getCount={this.getCount}

--- a/src/config/ConfigProvider.tsx
+++ b/src/config/ConfigProvider.tsx
@@ -14,6 +14,7 @@ export interface ConfigProviderContext {
     assetService: AssetService;
     endpoints: Endpoints;
     flow: string;
+    debug: boolean;
 }
 
 // ----------------------------------------------------------------------------------------------
@@ -26,7 +27,8 @@ export default class ConfigProvider extends React.Component<ConfigProviderProps>
     public static childContextTypes = {
         assetService: fakePropType,
         endpoints: fakePropType,
-        flow: fakePropType
+        flow: fakePropType,
+        debug: fakePropType
     };
 
     constructor(props: ConfigProviderProps) {
@@ -43,7 +45,8 @@ export default class ConfigProvider extends React.Component<ConfigProviderProps>
         return {
             assetService: this.props.config.assetService,
             endpoints: this.props.config.endpoints,
-            flow: this.props.config.flow
+            flow: this.props.config.flow,
+            debug: this.props.config.debug
         };
     }
 

--- a/src/flowTypes.ts
+++ b/src/flowTypes.ts
@@ -43,6 +43,7 @@ export interface FlowEditorConfig {
     localStorage: boolean;
     endpoints: Endpoints;
     flow: string;
+    debug?: boolean;
     assetService?: AssetService;
     path?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,11 @@
 /* istanbul ignore next */
 import FlowEditor from '~/components';
 
+declare global {
+    interface Window {
+        fe: any;
+    }
+}
+
 /* istanbul ignore next */
 export default FlowEditor;

--- a/src/store/__snapshots__/thunks.test.ts.snap
+++ b/src/store/__snapshots__/thunks.test.ts.snap
@@ -297,6 +297,7 @@ Array [
     "payload": Object {
       "editorState": Object {
         "createNodePosition": null,
+        "debug": null,
         "dragGroup": false,
         "dragSelection": null,
         "fetchingFlow": false,
@@ -314,6 +315,7 @@ Array [
     "payload": Object {
       "editorState": Object {
         "createNodePosition": null,
+        "debug": null,
         "dragGroup": false,
         "dragSelection": null,
         "fetchingFlow": false,
@@ -336,6 +338,7 @@ Array [
     "payload": Object {
       "editorState": Object {
         "createNodePosition": null,
+        "debug": null,
         "dragGroup": false,
         "dragSelection": null,
         "fetchingFlow": false,
@@ -364,6 +367,7 @@ Array [
     "payload": Object {
       "editorState": Object {
         "createNodePosition": null,
+        "debug": null,
         "dragGroup": false,
         "dragSelection": null,
         "fetchingFlow": false,
@@ -392,6 +396,7 @@ Array [
     "payload": Object {
       "editorState": Object {
         "createNodePosition": null,
+        "debug": null,
         "dragGroup": false,
         "dragSelection": null,
         "fetchingFlow": false,
@@ -1061,6 +1066,7 @@ Array [
     "payload": Object {
       "editorState": Object {
         "createNodePosition": null,
+        "debug": null,
         "dragGroup": false,
         "dragSelection": null,
         "fetchingFlow": false,
@@ -1104,6 +1110,7 @@ Array [
     "payload": Object {
       "editorState": Object {
         "createNodePosition": null,
+        "debug": null,
         "dragGroup": false,
         "dragSelection": null,
         "fetchingFlow": false,

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -14,6 +14,10 @@ export interface DragSelection {
     selected?: { [uuid: string]: boolean };
 }
 
+export interface DebugState {
+    showUUIDs: boolean;
+}
+
 export interface EditorState {
     language: Asset;
     translating: boolean;
@@ -25,6 +29,7 @@ export interface EditorState {
     ghostNode: RenderNode;
     dragGroup: boolean;
     dragSelection: DragSelection;
+    debug?: DebugState;
 }
 
 // Initial state
@@ -38,7 +43,8 @@ export const initialState: EditorState = {
     nodeDragging: false,
     ghostNode: null,
     dragSelection: null,
-    dragGroup: false
+    dragGroup: false,
+    debug: null
 };
 
 // Action Creator

--- a/src/testUtils/index.tsx
+++ b/src/testUtils/index.tsx
@@ -53,7 +53,8 @@ const flowEditorConfig: FlowEditorConfig = config;
 export const configProviderContext: ConfigProviderContext = {
     endpoints: flowEditorConfig.endpoints,
     flow: flowEditorConfig.flow,
-    assetService: new AssetService(flowEditorConfig)
+    assetService: new AssetService(flowEditorConfig),
+    debug: flowEditorConfig.debug
 };
 
 export const setMock = (implementation?: (...args: any[]) => any): Query<jest.Mock> =>

--- a/src/testUtils/index.tsx
+++ b/src/testUtils/index.tsx
@@ -36,7 +36,8 @@ export const contextTypes: { [key: string]: Function } = {
     store: fakePropType,
     endpoints: fakePropType,
     flow: fakePropType,
-    assetService: fakePropType
+    assetService: fakePropType,
+    debug: fakePropType
 };
 
 export const baseState: AppState = mutate(initialState, {

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -3,10 +3,6 @@ import { DebugState } from '~/store/editor';
 
 const mutate = require('immutability-helper');
 
-export const flowDebug = () => {
-    console.log('Debug Mode ON');
-};
-
 /* istanbul ignore next */
 export default class Debug {
     private props: FlowStoreProps;

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,0 +1,25 @@
+import { FlowStoreProps } from '~/components/flow/Flow';
+import { DebugState } from '~/store/editor';
+
+const mutate = require('immutability-helper');
+
+export const flowDebug = () => {
+    console.log('Debug Mode ON');
+};
+
+/* istanbul ignore next */
+export default class Debug {
+    private props: FlowStoreProps;
+    private state: DebugState;
+
+    constructor(props: FlowStoreProps, initial: DebugState) {
+        this.props = props;
+        this.state = initial || { showUUIDs: false };
+    }
+
+    public showUUIDs(): DebugState {
+        const updated = mutate(this.state, { $merge: { showUUIDs: true } });
+        this.props.mergeEditorState({ debug: updated });
+        return updated;
+    }
+}


### PR DESCRIPTION
Added state object to implement debugging features. Implemented first debug option which shows an overlay on each node with their uuid and copies it to the clipboard when clicked.

To try it, open the console and type:
`> window.fe.showUUIDs()`

