### PR TITLE
Set Result Asset Selector

### DIFF
--- a/src/components/fixy/Fixy.tsx
+++ b/src/components/fixy/Fixy.tsx
@@ -29,6 +29,10 @@ export class Fixy extends React.PureComponent<FixyProps, FixyState> {
         this.setState({ fixed });
     }
 
+    public componentWillUnmount(): void {
+        window.removeEventListener('scroll', this.handleScroll);
+    }
+
     public componentDidMount(): void {
         const top = this.ele.getBoundingClientRect().top + window.scrollY;
         const fixed = window.scrollY > top;

--- a/src/components/flow/actions/setrunresult/SetRunResultForm.test.ts
+++ b/src/components/flow/actions/setrunresult/SetRunResultForm.test.ts
@@ -1,5 +1,6 @@
 import SetRunResultForm from '~/components/flow/actions/setrunresult/SetRunResultForm';
 import { ActionFormProps } from '~/components/flow/props';
+import { Asset, AssetType } from '~/store/flowContext';
 import { composeComponentTestUtils, mock } from '~/testUtils';
 import { createSetRunResultAction, getActionFormProps } from '~/testUtils/assetCreators';
 import * as utils from '~/utils';
@@ -10,6 +11,12 @@ const { setup } = composeComponentTestUtils<ActionFormProps>(
 );
 
 mock(utils, 'createUUID', utils.seededUUIDs());
+
+const resultName: Asset = {
+    name: 'Result Name',
+    id: utils.snakify('Result Name'),
+    type: AssetType.Result
+};
 
 describe(SetRunResultForm.name, () => {
     describe('render', () => {
@@ -23,7 +30,7 @@ describe(SetRunResultForm.name, () => {
         it('should save changes', () => {
             const { instance, props } = setup(true);
 
-            instance.handleNameUpdate('Result Name');
+            instance.handleNameUpdate([resultName]);
             instance.handleValueUpdate('Result Value');
             instance.handleCategoryUpdate('Result Category');
 
@@ -40,7 +47,7 @@ describe(SetRunResultForm.name, () => {
                 nodeSettings: { $merge: { originalAction: null } }
             });
 
-            instance.handleNameUpdate('Result Name');
+            instance.handleNameUpdate([resultName]);
             instance.handleValueUpdate('Result Value');
             instance.handleCategoryUpdate('Result Category');
             instance.handleSave();
@@ -55,7 +62,7 @@ describe(SetRunResultForm.name, () => {
                 $merge: { onClose: jest.fn(), updateAction: jest.fn() }
             });
 
-            instance.handleNameUpdate("Don't Save Me");
+            instance.handleNameUpdate([resultName]);
             instance.getButtons().secondary.onClick();
             expect(props.onClose).toHaveBeenCalled();
             expect(props.updateAction).not.toHaveBeenCalled();

--- a/src/components/flow/actions/setrunresult/SetRunResultForm.tsx
+++ b/src/components/flow/actions/setrunresult/SetRunResultForm.tsx
@@ -5,13 +5,22 @@ import { hasErrors } from '~/components/flow/actions/helpers';
 import { initializeForm, stateToAction } from '~/components/flow/actions/setrunresult/helpers';
 import * as styles from '~/components/flow/actions/setrunresult/SetRunResult.scss';
 import { ActionFormProps } from '~/components/flow/props';
+import AssetSelector from '~/components/form/assetselector/AssetSelector';
 import TextInputElement from '~/components/form/textinput/TextInputElement';
 import TypeList from '~/components/nodeeditor/TypeList';
-import { FormState, mergeForm, StringEntry, ValidationFailure } from '~/store/nodeEditor';
+import { Asset, AssetType } from '~/store/flowContext';
+import {
+    AssetEntry,
+    FormState,
+    mergeForm,
+    StringEntry,
+    ValidationFailure
+} from '~/store/nodeEditor';
 import { validate, validateRequired } from '~/store/validators';
+import { snakify } from '~/utils';
 
 export interface SetRunResultFormState extends FormState {
-    name: StringEntry;
+    name: AssetEntry;
     value: StringEntry;
     category: StringEntry;
 }
@@ -30,8 +39,8 @@ export default class SetRunResultForm extends React.PureComponent<
         });
     }
 
-    public handleNameUpdate(name: string): boolean {
-        return this.handleUpdate({ name });
+    private handleNameUpdate(selected: Asset[]): void {
+        this.setState({ name: { value: selected[0] } });
     }
 
     public handleValueUpdate(value: string): boolean {
@@ -42,7 +51,7 @@ export default class SetRunResultForm extends React.PureComponent<
         return this.handleUpdate({ category });
     }
 
-    private handleUpdate(keys: { name?: string; value?: string; category?: string }): boolean {
+    private handleUpdate(keys: { name?: Asset; value?: string; category?: string }): boolean {
         const updates: Partial<SetRunResultFormState> = {};
 
         if (keys.hasOwnProperty('name')) {
@@ -83,6 +92,14 @@ export default class SetRunResultForm extends React.PureComponent<
         };
     }
 
+    private handleCreateAssetFromInput(input: string): Asset {
+        return {
+            id: snakify(input),
+            name: input,
+            type: AssetType.Result
+        };
+    }
+
     public render(): JSX.Element {
         const typeConfig = this.props.typeConfig;
         return (
@@ -97,14 +114,18 @@ export default class SetRunResultForm extends React.PureComponent<
                     onChange={this.props.onTypeChange}
                 />
                 <div className={styles.form}>
-                    <TextInputElement
-                        __className={styles.name}
+                    <AssetSelector
                         name="Name"
-                        showLabel={true}
-                        onChange={this.handleNameUpdate}
+                        assets={this.props.assetStore.results}
                         entry={this.state.name}
+                        searchable={true}
+                        createPrefix="New: "
+                        onChange={this.handleNameUpdate}
+                        createAssetFromInput={this.handleCreateAssetFromInput}
+                        showLabel={true}
                         helpText="The name of the result, used to reference later, for example: @run.results.my_result_name"
                     />
+
                     <TextInputElement
                         __className={styles.value}
                         name="Value"

--- a/src/components/flow/actions/setrunresult/__snapshots__/SetRunResultForm.test.ts.snap
+++ b/src/components/flow/actions/setrunresult/__snapshots__/SetRunResultForm.test.ts.snap
@@ -33,16 +33,22 @@ exports[`SetRunResultForm render should render 1`] = `
   <div
     className="form"
   >
-    <Connect(TextInputElement)
-      __className="name"
+    <AssetSelector
+      createAssetFromInput={[Function]}
+      createPrefix="New: "
       entry={
         Object {
-          "value": "Name",
+          "value": Object {
+            "id": "name",
+            "name": "Name",
+            "type": "result",
+          },
         }
       }
       helpText="The name of the result, used to reference later, for example: @run.results.my_result_name"
       name="Name"
       onChange={[Function]}
+      searchable={true}
       showLabel={true}
     />
     <Connect(TextInputElement)
@@ -96,8 +102,11 @@ Object {
     "value": "Result Category",
   },
   "name": Object {
-    "validationFailures": Array [],
-    "value": "Result Name",
+    "value": Object {
+      "id": "result_name",
+      "name": "Result Name",
+      "type": "result",
+    },
   },
   "valid": true,
   "value": Object {

--- a/src/components/flow/actions/setrunresult/helpers.ts
+++ b/src/components/flow/actions/setrunresult/helpers.ts
@@ -2,14 +2,18 @@ import { getActionUUID } from '~/components/flow/actions/helpers';
 import { SetRunResultFormState } from '~/components/flow/actions/setrunresult/SetRunResultForm';
 import { Types } from '~/config/interfaces';
 import { SetRunResult } from '~/flowTypes';
+import { AssetType } from '~/store/flowContext';
 import { NodeEditorSettings } from '~/store/nodeEditor';
+import { snakify } from '~/utils';
 
 export const initializeForm = (settings: NodeEditorSettings): SetRunResultFormState => {
     if (settings.originalAction && settings.originalAction.type === Types.set_run_result) {
         const action = settings.originalAction as SetRunResult;
 
         return {
-            name: { value: action.name },
+            name: {
+                value: { id: snakify(action.name), name: action.name, type: AssetType.Result }
+            },
             value: { value: action.value },
             category: { value: action.category },
             valid: true
@@ -17,7 +21,7 @@ export const initializeForm = (settings: NodeEditorSettings): SetRunResultFormSt
     }
 
     return {
-        name: { value: '' },
+        name: { value: null },
         value: { value: '' },
         category: { value: '' },
         valid: false
@@ -30,7 +34,7 @@ export const stateToAction = (
 ): SetRunResult => {
     return {
         type: Types.set_run_result,
-        name: state.name.value,
+        name: state.name.value.name,
         value: state.value.value,
         category: state.category.value,
         uuid: getActionUUID(settings, Types.set_run_result)

--- a/src/components/form/assetselector/AssetSelector.tsx
+++ b/src/components/form/assetselector/AssetSelector.tsx
@@ -264,20 +264,27 @@ export default class AssetSelector extends React.Component<AssetSelectorProps, A
 
     public handleCreateOption(input: string): void {
         // mark us as loading
-        this.setState({ isLoading: true, message: null });
-        const payload = this.props.createAssetFromInput(input);
-        postNewAsset(this.props.assets, payload)
-            .then((asset: Asset) => {
-                this.setState({ isLoading: false });
-                this.props.onAssetCreated(asset);
-            })
-            .catch(error => {
-                console.log(error);
-                this.setState({
-                    message: `Couldn't create new ${this.props.assets.type} "${input}"`,
-                    isLoading: false
+        const asset: Asset = this.props.createAssetFromInput(input);
+
+        if (this.props.assets.endpoint) {
+            this.setState({ isLoading: true, message: null });
+
+            postNewAsset(this.props.assets, asset)
+                .then((result: Asset) => {
+                    this.setState({ isLoading: false });
+                    this.props.onAssetCreated(result);
+                    this.props.onChange([result]);
+                })
+                .catch(error => {
+                    console.log(error);
+                    this.setState({
+                        message: `Couldn't create new ${this.props.assets.type} "${input}"`,
+                        isLoading: false
+                    });
                 });
-            });
+        } else {
+            this.props.onChange([asset]);
+        }
     }
 
     public render(): JSX.Element {
@@ -310,24 +317,31 @@ export default class AssetSelector extends React.Component<AssetSelectorProps, A
             );
 
             return (
-                <Creatable
-                    {...commonAttributes}
-                    options={localMatches.sort(this.props.sortFunction || sortByName)}
-                    isValidNewOption={this.handleCheckValid}
-                    formatCreateLabel={this.handleCreatePrompt}
-                    getNewOptionData={this.handleGetNewOptionData}
-                    onCreateOption={this.handleCreateOption}
+                <FormElement
+                    name={this.props.name}
+                    entry={this.props.entry}
+                    showLabel={this.props.showLabel}
+                    helpText={this.props.helpText}
+                >
+                    <Creatable
+                        {...commonAttributes}
+                        options={localMatches.sort(this.props.sortFunction || sortByName)}
+                        isValidNewOption={this.handleCheckValid}
+                        formatCreateLabel={this.handleCreatePrompt}
+                        getNewOptionData={this.handleGetNewOptionData}
+                        onCreateOption={this.handleCreateOption}
 
-                    // We are currently using Creatable since our assets are currently
-                    // being preloaded on page load and because of isLoaded not being
-                    // honored when set manually (this is needed to perform onCreateOption
-                    // via call to asset endpoint with feedback). Once that fix is merged,
-                    // we can consider using AsyncCreateable
-                    //
-                    // See: https://github.com/JedWatson/react-select/issues/2986
-                    //      https://github.com/JedWatson/react-select/pull/3319
-                    //
-                />
+                        // We are currently using Creatable since our assets are currently
+                        // being preloaded on page load and because of isLoaded not being
+                        // honored when set manually (this is needed to perform onCreateOption
+                        // via call to asset endpoint with feedback). Once that fix is merged,
+                        // we can consider using AsyncCreateable
+                        //
+                        // See: https://github.com/JedWatson/react-select/issues/2986
+                        //      https://github.com/JedWatson/react-select/pull/3319
+                        //
+                    />
+                </FormElement>
             );
         } else {
             // the default options should be true if there is an endpoint
@@ -352,6 +366,7 @@ export default class AssetSelector extends React.Component<AssetSelectorProps, A
                     name={this.props.name}
                     entry={this.props.entry}
                     showLabel={this.props.showLabel}
+                    helpText={this.props.helpText}
                 >
                     <Async
                         {...commonAttributes}


### PR DESCRIPTION
Use AssetSelector when naming flow results to make it easier to reuse result names.

Fixes: #516 