### PR TITLE
Changes to set language

### DIFF
--- a/src/components/flow/actions/sendbroadcast/__snapshots__/SendBroadcastForm.test.ts.snap
+++ b/src/components/flow/actions/sendbroadcast/__snapshots__/SendBroadcastForm.test.ts.snap
@@ -47,7 +47,14 @@ exports[`SendBroadcastForm render should render an empty form with no action 2`]
     onChange={[MockFunction]}
   />
   <AssetSelector
-    completion={Object {}}
+    completion={
+      Object {
+        "languages": Object {
+          "items": Object {},
+          "type": "language",
+        },
+      }
+    }
     entry={
       Object {
         "value": Array [],
@@ -112,7 +119,14 @@ exports[`SendBroadcastForm render should render self, children with base props 1
     onChange={[MockFunction]}
   />
   <AssetSelector
-    completion={Object {}}
+    completion={
+      Object {
+        "languages": Object {
+          "items": Object {},
+          "type": "language",
+        },
+      }
+    }
     entry={
       Object {
         "value": Array [

--- a/src/components/flow/actions/startsession/__snapshots__/StartSessionForm.test.ts.snap
+++ b/src/components/flow/actions/startsession/__snapshots__/StartSessionForm.test.ts.snap
@@ -52,7 +52,14 @@ exports[`StartSessionForm render should render an empty form with no action 2`] 
   />
   <div>
     <AssetSelector
-      completion={Object {}}
+      completion={
+        Object {
+          "languages": Object {
+            "items": Object {},
+            "type": "language",
+          },
+        }
+      }
       entry={
         Object {
           "value": Array [],
@@ -119,7 +126,14 @@ exports[`StartSessionForm render should render self, children with base props 1`
   />
   <div>
     <AssetSelector
-      completion={Object {}}
+      completion={
+        Object {
+          "languages": Object {
+            "items": Object {},
+            "type": "language",
+          },
+        }
+      }
       entry={
         Object {
           "value": Array [

--- a/src/components/flow/actions/updatecontact/UpdateContact.tsx
+++ b/src/components/flow/actions/updatecontact/UpdateContact.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { getLanguageForCode } from 'components/flow/actions/updatecontact/helpers';
 import { Types } from 'config/interfaces';
 import {
   SetContactAttribute,
@@ -6,6 +6,7 @@ import {
   SetContactLanguage,
   SetContactName
 } from 'flowTypes';
+import * as React from 'react';
 import { emphasize } from 'utils';
 
 const withEmph = (text: string, emph: boolean) => (emph ? emphasize(text) : text);
@@ -26,14 +27,18 @@ export const renderSetText = (
   }
 };
 
-const UpdateContactComp: React.SFC<SetContactAttribute> = action => {
+const UpdateContactComp: React.SFC<SetContactAttribute> = (action: any) => {
   switch (action.type) {
     case Types.set_contact_field:
       return renderSetText(action.field.name, action.value, true);
     case Types.set_contact_channel:
       return renderSetText('channel', (action as SetContactChannel).channel.name);
     case Types.set_contact_language:
-      return renderSetText('language', (action as SetContactLanguage).language);
+      const setLanguageAction = action as SetContactLanguage;
+      return renderSetText(
+        'language',
+        getLanguageForCode(setLanguageAction.language, action.languages)
+      );
     case Types.set_contact_name:
       return renderSetText('name', (action as SetContactName).name);
   }

--- a/src/components/flow/actions/updatecontact/UpdateContactForm.tsx
+++ b/src/components/flow/actions/updatecontact/UpdateContactForm.tsx
@@ -29,14 +29,13 @@ export default class UpdateContactForm extends React.Component<
   UpdateContactFormState
 > {
   public static contextTypes = {
-    assetService: fakePropType,
     config: fakePropType
   };
 
   constructor(props: ActionFormProps) {
     super(props);
 
-    this.state = initializeForm(this.props.nodeSettings);
+    this.state = initializeForm(this.props.nodeSettings, this.props.assetStore);
 
     bindCallbacks(this, {
       include: [/^get/, /^on/, /^handle/]
@@ -219,6 +218,7 @@ export default class UpdateContactForm extends React.Component<
           searchable={true}
           valueClearable={true}
           onChange={this.handleLanguageUpdate}
+          shouldExclude={(asset: Asset) => asset.id === 'base'}
         />
       );
     } else if (this.state.type === Types.set_contact_name) {

--- a/src/components/flow/actions/updatecontact/__snapshots__/UpdateContactForm.test.ts.snap
+++ b/src/components/flow/actions/updatecontact/__snapshots__/UpdateContactForm.test.ts.snap
@@ -273,6 +273,12 @@ exports[`UpdateContactForm render initial for language 1`] = `
     className="value"
   >
     <AssetSelector
+      assets={
+        Object {
+          "items": Object {},
+          "type": "language",
+        }
+      }
       entry={
         Object {
           "value": Object {
@@ -287,6 +293,7 @@ exports[`UpdateContactForm render initial for language 1`] = `
       onChange={[Function]}
       placeholder="Select the language to use for this contact"
       searchable={true}
+      shouldExclude={[Function]}
       valueClearable={true}
     />
   </div>

--- a/src/components/flow/actions/updatecontact/helpers.ts
+++ b/src/components/flow/actions/updatecontact/helpers.ts
@@ -12,7 +12,7 @@ import {
   SetContactLanguage,
   SetContactName
 } from 'flowTypes';
-import { Asset, AssetType, REMOVE_VALUE_ASSET } from 'store/flowContext';
+import { Asset, AssetMap, AssetStore, AssetType, REMOVE_VALUE_ASSET } from 'store/flowContext';
 import { AssetEntry, FormState, NodeEditorSettings, StringEntry } from 'store/nodeEditor';
 
 export interface UpdateContactFormState extends FormState {
@@ -24,7 +24,10 @@ export interface UpdateContactFormState extends FormState {
   fieldValue: StringEntry;
 }
 
-export const initializeForm = (settings: NodeEditorSettings): UpdateContactFormState => {
+export const initializeForm = (
+  settings: NodeEditorSettings,
+  assetStore: AssetStore
+): UpdateContactFormState => {
   const state: UpdateContactFormState = {
     type: Types.set_contact_name,
     valid: false,
@@ -61,7 +64,7 @@ export const initializeForm = (settings: NodeEditorSettings): UpdateContactFormS
           state.language = {
             value: languageToAsset({
               iso: languageAction.language,
-              name: languageAction.language
+              name: getLanguageForCode(languageAction.language, assetStore.languages.items)
             })
           };
           return state;
@@ -196,7 +199,10 @@ export const channelToAsset = ({ uuid, name }: Channel) => {
   };
 };
 
-/* export const createNewOption = composeCreateNewOption({
-    idCb: label => snakify(label),
-    type: AssetType.Field
-});*/
+export const getLanguageForCode = (code: string, languages: AssetMap) => {
+  let lang = code;
+  if (languages && lang in languages) {
+    lang = languages[lang].name;
+  }
+  return lang;
+};

--- a/src/components/flow/node/Node.tsx
+++ b/src/components/flow/node/Node.tsx
@@ -56,6 +56,7 @@ export interface NodePassedProps {
 
 export interface NodeStoreProps {
   results: AssetMap;
+  languages: AssetMap;
   activeCount: number;
   containerOffset: { top: number; left: number };
   translating: boolean;
@@ -271,7 +272,9 @@ export class NodeComp extends React.Component<NodeProps> {
               selected={this.props.selected}
               action={action}
               first={idx === 0}
-              render={(anyAction: AnyAction) => <ActionDiv {...anyAction} />}
+              render={(anyAction: AnyAction) => (
+                <ActionDiv {...anyAction} languages={this.props.languages} />
+              )}
             />
           );
         }
@@ -436,7 +439,8 @@ const mapStateToProps = (
       nodes,
       definition,
       assetStore: {
-        results: { items }
+        results: { items: results },
+        languages: { items: languages }
       }
     },
     editorState: { translating, debug, ghostNode, simulating, containerOffset, activity }
@@ -462,7 +466,8 @@ const mapStateToProps = (
   const activeCount = activity.nodes[props.nodeUUID] || 0;
 
   return {
-    results: items,
+    results,
+    languages,
     activeCount,
     containerOffset,
     translating,

--- a/src/testUtils/assetCreators.ts
+++ b/src/testUtils/assetCreators.ts
@@ -378,7 +378,7 @@ export const createWebhookRouterNode = (): FlowNode => {
 };
 
 export const getActionFormProps = (action: AnyAction): ActionFormProps => ({
-  assetStore: {},
+  assetStore: { languages: { items: {}, type: AssetType.Language } },
   addAsset: jest.fn(),
   updateAction: jest.fn(),
   onClose: jest.fn(),


### PR DESCRIPTION
* Use org language name if present
* Exclude default/base from set language options

Fixes: #646 

Note: if definitions contain languages that are not in the org, a language code will be shown instead