### PR TITLE
Don't save empty quick reply lists on localization

### DIFF
--- a/src/components/flow/actions/localization/MsgLocalizationForm.test.ts
+++ b/src/components/flow/actions/localization/MsgLocalizationForm.test.ts
@@ -59,6 +59,20 @@ describe(SendMsgLocalizationForm.name, () => {
       expect(props.updateLocalizations).toHaveBeenCalled();
       expect(props.updateLocalizations).toMatchCallSnapshot();
     });
+
+    it('should ignore empty quick replies', () => {
+      const { instance, props } = setup(true, {
+        $merge: { updateLocalizations: jest.fn(), onClose: jest.fn() }
+      });
+
+      instance.handleQuickRepliesUpdate([]);
+      expect(instance.state).toMatchSnapshot();
+
+      instance.handleSave();
+      expect(props.onClose).toHaveBeenCalled();
+      expect(props.updateLocalizations).toHaveBeenCalled();
+      expect(props.updateLocalizations).toMatchCallSnapshot();
+    });
   });
 
   describe('cancel', () => {

--- a/src/components/flow/actions/localization/MsgLocalizationForm.tsx
+++ b/src/components/flow/actions/localization/MsgLocalizationForm.tsx
@@ -77,6 +77,7 @@ export default class MsgLocalizationForm extends React.Component<
 
     const updated = mergeForm(this.state, updates);
     this.setState(updated);
+
     return updated.valid;
   }
 
@@ -96,7 +97,7 @@ export default class MsgLocalizationForm extends React.Component<
         translations.text = text.value;
       }
 
-      if (quickReplies.value) {
+      if (quickReplies.value && quickReplies.value.length > 0) {
         translations.quick_replies = quickReplies.value;
       }
 

--- a/src/components/flow/actions/localization/__snapshots__/MsgLocalizationForm.test.ts.snap
+++ b/src/components/flow/actions/localization/__snapshots__/MsgLocalizationForm.test.ts.snap
@@ -132,6 +132,34 @@ exports[`MsgLocalizationForm render should render 1`] = `
 </Dialog>
 `;
 
+exports[`MsgLocalizationForm updates should ignore empty quick replies 1`] = `
+Object {
+  "audio": Object {
+    "value": null,
+  },
+  "message": Object {
+    "value": "",
+  },
+  "quickReplies": Object {
+    "validationFailures": Array [],
+    "value": Array [],
+  },
+  "valid": true,
+}
+`;
+
+exports[`MsgLocalizationForm updates should ignore empty quick replies 2`] = `
+Array [
+  "spa",
+  Array [
+    Object {
+      "translations": Object {},
+      "uuid": "b1f332f3-bdd3-4891-aec5-1843a712dbf1",
+    },
+  ],
+]
+`;
+
 exports[`MsgLocalizationForm updates should save changes 1`] = `
 Object {
   "audio": Object {

--- a/src/components/flow/actions/sendmsg/SendMsg.module.scss
+++ b/src/components/flow/actions/sendmsg/SendMsg.module.scss
@@ -1,7 +1,8 @@
-@import "variables.module.scss";
+@import 'variables.module.scss';
 
 .quick_replies {
   display: inline-block;
+  color: $gray;
 }
 
 .attachment {


### PR DESCRIPTION
Also shows translated quick replies in gray instead of red.

Fixes: #660 