### PR TITLE
Split by phone

### DIFF
--- a/src/components/flow/node/Node.tsx
+++ b/src/components/flow/node/Node.tsx
@@ -208,10 +208,8 @@ export class NodeComp extends React.Component<NodeProps> {
 
   private hasMissing(): boolean {
     // see if we are splitting on a missing result
-    if (
-      this.props.renderNode.ui.type === Types.split_by_run_result ||
-      this.props.renderNode.ui.type === Types.split_by_run_result_delimited
-    ) {
+    const type = getType(this.props.renderNode);
+    if (type === Types.split_by_run_result || type === Types.split_by_run_result_delimited) {
       if (!(this.props.renderNode.ui.config.operand.id in this.props.results)) {
         return true;
       }
@@ -295,20 +293,14 @@ export class NodeComp extends React.Component<NodeProps> {
     let summary: JSX.Element = null;
 
     // Router node display logic
-    if (this.props.renderNode.ui.type !== Types.execute_actions) {
-      let type = this.props.renderNode.node.router.type;
-
-      if (this.props.renderNode.ui.type) {
-        type = getType(this.props.renderNode);
-      }
-
+    const type = getType(this.props.renderNode);
+    if (type !== Types.execute_actions) {
       const config = getTypeConfig(type);
-
       let title: string = config.name;
 
       const switchRouter = getSwitchRouter(this.props.renderNode.node);
       if (switchRouter) {
-        if (this.props.renderNode.ui.type === Types.split_by_contact_field) {
+        if (type === Types.split_by_contact_field && this.props.renderNode.ui.config.operand.name) {
           title = `Split by ${this.props.renderNode.ui.config.operand.name}`;
         }
       }
@@ -325,8 +317,7 @@ export class NodeComp extends React.Component<NodeProps> {
 
       if (
         title === null &&
-        (this.props.renderNode.ui.type === Types.split_by_run_result ||
-          this.props.renderNode.ui.type === Types.split_by_run_result_delimited)
+        (type === Types.split_by_run_result || type === Types.split_by_run_result_delimited)
       ) {
         if (this.props.renderNode.ui.config.operand.id in this.props.results) {
           title = `Split by ${this.props.results[this.props.renderNode.ui.config.operand.id].name}`;

--- a/src/components/flow/routers/expression/helpers.ts
+++ b/src/components/flow/routers/expression/helpers.ts
@@ -8,6 +8,7 @@ import {
 } from 'components/flow/routers/helpers';
 import { DEFAULT_OPERAND } from 'components/nodeeditor/constants';
 import { Types } from 'config/interfaces';
+import { getType } from 'config/typeConfigs';
 import { Router, RouterTypes, SwitchRouter } from 'flowTypes';
 import { RenderNode } from 'store/flowContext';
 import { NodeEditorSettings, StringEntry } from 'store/nodeEditor';
@@ -20,7 +21,7 @@ export const nodeToState = (settings: NodeEditorSettings): ExpressionRouterFormS
 
   let operand = DEFAULT_OPERAND;
 
-  if (settings.originalNode && settings.originalNode.ui.type === Types.split_by_expression) {
+  if (settings.originalNode && getType(settings.originalNode) === Types.split_by_expression) {
     const router = settings.originalNode.node.router as SwitchRouter;
     if (router) {
       if (hasCases(settings.originalNode.node)) {

--- a/src/components/flow/routers/field/helpers.ts
+++ b/src/components/flow/routers/field/helpers.ts
@@ -95,7 +95,7 @@ export const stateToNode = (
   let operand = DEFAULT_OPERAND;
   const asset = state.field.value;
   if (asset.type === AssetType.Scheme) {
-    operand = `@(format_urn(urns.${asset.id}))`;
+    operand = `@(urn_parts(urns.${asset.id}).path)`;
   } else if (asset.type === AssetType.Field) {
     operand = `@contact.fields.${asset.id}`;
   } else {

--- a/src/components/flow/routers/field/helpers.ts
+++ b/src/components/flow/routers/field/helpers.ts
@@ -10,7 +10,7 @@ import {
 import { getContactProperties } from 'components/helpers';
 import { DEFAULT_OPERAND } from 'components/nodeeditor/constants';
 import { FlowTypes, Types } from 'config/interfaces';
-import { Scheme, SCHEMES } from 'config/typeConfigs';
+import { getType, Scheme, SCHEMES } from 'config/typeConfigs';
 import { Router, RouterTypes, SwitchRouter } from 'flowTypes';
 import { Asset, AssetStore, AssetType, RenderNode } from 'store/flowContext';
 import { NodeEditorSettings, StringEntry } from 'store/nodeEditor';
@@ -37,7 +37,8 @@ export const nodeToState = (
 
   let field: any = null;
 
-  if (settings.originalNode && settings.originalNode.ui.type === Types.split_by_contact_field) {
+  const type = getType(settings.originalNode);
+  if (settings.originalNode && type === Types.split_by_contact_field) {
     const router = settings.originalNode.node.router as SwitchRouter;
 
     if (router) {

--- a/src/components/flow/routers/groups/helpers.ts
+++ b/src/components/flow/routers/groups/helpers.ts
@@ -3,6 +3,7 @@ import { GroupsRouterFormState } from 'components/flow/routers/groups/GroupsRout
 import { createRenderNode, getSwitchRouter, resolveRoutes } from 'components/flow/routers/helpers';
 import { GROUPS_OPERAND } from 'components/nodeeditor/constants';
 import { Operators, Types } from 'config/interfaces';
+import { getType } from 'config/typeConfigs';
 import { Category, FlowNode, RouterTypes, SwitchRouter } from 'flowTypes';
 import { Asset, AssetType, RenderNode } from 'store/flowContext';
 import { NodeEditorSettings } from 'store/nodeEditor';
@@ -15,7 +16,7 @@ export const nodeToState = (settings: NodeEditorSettings): GroupsRouterFormState
     valid: false
   };
 
-  if (settings.originalNode.ui.type === Types.split_by_groups) {
+  if (getType(settings.originalNode) === Types.split_by_groups) {
     state.groups.value = extractGroups(settings.originalNode.node);
     state.resultName = {
       value: (settings.originalNode.node.router as SwitchRouter).result_name || ''

--- a/src/components/flow/routers/localization/helpers.ts
+++ b/src/components/flow/routers/localization/helpers.ts
@@ -1,4 +1,5 @@
 import { Types } from 'config/interfaces';
+import { getType } from 'config/typeConfigs';
 import { Case, Category, SwitchRouter } from 'flowTypes';
 import { LocalizedObject } from 'services/Localization';
 import { RenderNode } from 'store/flowContext';
@@ -20,7 +21,7 @@ export const getOriginalCategory = (nodeSettings: NodeEditorSettings, uuid: stri
 };
 
 export const hasLocalizableCases = (renderNode: RenderNode) => {
-  const type = renderNode.ui.type;
+  const type = getType(renderNode);
   return type === Types.wait_for_response || type === Types.split_by_expression;
 };
 

--- a/src/components/flow/routers/random/helpers.ts
+++ b/src/components/flow/routers/random/helpers.ts
@@ -2,6 +2,7 @@ import { createRenderNode } from 'components/flow/routers/helpers';
 import { RandomRouterFormState } from 'components/flow/routers/random/RandomRouterForm';
 import { SelectOption } from 'components/form/select/SelectElement';
 import { Types } from 'config/interfaces';
+import { getType } from 'config/typeConfigs';
 import { Category, Exit, Router, RouterTypes } from 'flowTypes';
 import { RenderNode } from 'store/flowContext';
 import { NodeEditorSettings, StringEntry } from 'store/nodeEditor';
@@ -27,7 +28,7 @@ export const nodeToState = (settings: NodeEditorSettings): RandomRouterFormState
   let buckets = 2;
 
   let categories: Category[] = [];
-  if (settings.originalNode && settings.originalNode.ui.type === Types.split_by_random) {
+  if (settings.originalNode && getType(settings.originalNode) === Types.split_by_random) {
     const router = settings.originalNode.node.router as Router;
     resultName = { value: router.result_name || '' };
     buckets = settings.originalNode.node.exits.length;
@@ -56,7 +57,9 @@ export const stateToNode = (
   }
 
   const exits =
-    settings.originalNode.ui.type === Types.split_by_random ? settings.originalNode.node.exits : [];
+    getType(settings.originalNode) === Types.split_by_random
+      ? settings.originalNode.node.exits
+      : [];
 
   const count = parseInt(state.bucketChoice.value.value, 10);
   exits.splice(count, exits.length - count);

--- a/src/components/flow/routers/response/helpers.ts
+++ b/src/components/flow/routers/response/helpers.ts
@@ -8,6 +8,7 @@ import {
 import { ResponseRouterFormState } from 'components/flow/routers/response/ResponseRouterForm';
 import { DEFAULT_OPERAND } from 'components/nodeeditor/constants';
 import { Types } from 'config/interfaces';
+import { getType } from 'config/typeConfigs';
 import { Router, RouterTypes, SwitchRouter, Wait, WaitTypes } from 'flowTypes';
 import { RenderNode } from 'store/flowContext';
 import { NodeEditorSettings, StringEntry } from 'store/nodeEditor';
@@ -19,7 +20,7 @@ export const nodeToState = (settings: NodeEditorSettings): ResponseRouterFormSta
   let resultName: StringEntry = { value: 'Result' };
   let timeout = 0;
 
-  if (settings.originalNode && settings.originalNode.ui.type === Types.wait_for_response) {
+  if (settings.originalNode && getType(settings.originalNode) === Types.wait_for_response) {
     const router = settings.originalNode.node.router as SwitchRouter;
     if (router) {
       if (hasCases(settings.originalNode.node)) {

--- a/src/components/flow/routers/result/helpers.ts
+++ b/src/components/flow/routers/result/helpers.ts
@@ -7,6 +7,7 @@ import {
 } from 'components/flow/routers/helpers';
 import { SelectOption } from 'components/form/select/SelectElement';
 import { Types } from 'config/interfaces';
+import { getType } from 'config/typeConfigs';
 import { Router, RouterTypes, SwitchRouter } from 'flowTypes';
 import { AssetStore, RenderNode } from 'store/flowContext';
 import { NodeEditorSettings, StringEntry } from 'store/nodeEditor';
@@ -53,9 +54,11 @@ export const nodeToState = (
   let delimiter = ' ';
   let shouldDelimit = false;
 
+  const type = getType(settings.originalNode);
+
   if (
-    (settings.originalNode && settings.originalNode.ui.type === Types.split_by_run_result) ||
-    settings.originalNode.ui.type === Types.split_by_run_result_delimited
+    (settings.originalNode && type === Types.split_by_run_result) ||
+    type === Types.split_by_run_result_delimited
   ) {
     const router = settings.originalNode.node.router as SwitchRouter;
 
@@ -75,7 +78,7 @@ export const nodeToState = (
           : null;
     }
 
-    if (settings.originalNode.ui.type === Types.split_by_run_result_delimited) {
+    if (type === Types.split_by_run_result_delimited) {
       fieldNumber = config.index;
       delimiter = config.delimiter;
       shouldDelimit = true;

--- a/src/components/flow/routers/subflow/helpers.ts
+++ b/src/components/flow/routers/subflow/helpers.ts
@@ -2,6 +2,7 @@ import { createRenderNode } from 'components/flow/routers/helpers';
 import { SubflowRouterFormState } from 'components/flow/routers/subflow/SubflowRouterForm';
 import { SUBFLOW_OPERAND } from 'components/nodeeditor/constants';
 import { Operators, Types } from 'config/interfaces';
+import { getType } from 'config/typeConfigs';
 import {
   Case,
   Category,
@@ -17,7 +18,7 @@ import { NodeEditorSettings } from 'store/nodeEditor';
 import { createUUID } from 'utils';
 
 export const nodeToState = (settings: NodeEditorSettings): SubflowRouterFormState => {
-  if (settings.originalNode.ui.type === Types.split_by_subflow) {
+  if (getType(settings.originalNode) === Types.split_by_subflow) {
     const action = (settings.originalAction ||
       (settings.originalNode.node.actions.length > 0 &&
         settings.originalNode.node.actions[0])) as StartFlow;
@@ -50,7 +51,7 @@ export const stateToNode = (
   let cases: Case[];
   let categories: Category[];
 
-  if (settings.originalNode.ui.type === Types.split_by_subflow) {
+  if (getType(settings.originalNode) === Types.split_by_subflow) {
     ({ exits } = settings.originalNode.node);
     ({ cases, categories } = settings.originalNode.node.router as SwitchRouter);
   } else {

--- a/src/components/flow/routers/wait/helpers.ts
+++ b/src/components/flow/routers/wait/helpers.ts
@@ -2,13 +2,14 @@ import { createRenderNode, resolveRoutes } from 'components/flow/routers/helpers
 import { WaitRouterFormState } from 'components/flow/routers/wait/WaitRouterForm';
 import { DEFAULT_OPERAND } from 'components/nodeeditor/constants';
 import { Type, Types } from 'config/interfaces';
+import { getType } from 'config/typeConfigs';
 import { HintTypes, Router, RouterTypes, SwitchRouter, Wait, WaitTypes } from 'flowTypes';
 import { RenderNode } from 'store/flowContext';
 import { NodeEditorSettings, StringEntry } from 'store/nodeEditor';
 
 export const nodeToState = (settings: NodeEditorSettings): WaitRouterFormState => {
   let resultName: StringEntry = { value: 'Result' };
-  if (settings.originalNode && settings.originalNode.ui.type === Types.wait_for_response) {
+  if (settings.originalNode && getType(settings.originalNode) === Types.wait_for_response) {
     const router = settings.originalNode.node.router as SwitchRouter;
     if (router) {
       resultName = { value: router.result_name || '' };

--- a/src/components/flow/routers/webhook/helpers.ts
+++ b/src/components/flow/routers/webhook/helpers.ts
@@ -2,6 +2,7 @@ import { createWebhookBasedNode } from 'components/flow/routers/helpers';
 import { WebhookRouterFormState } from 'components/flow/routers/webhook/WebhookRouterForm';
 import { DEFAULT_BODY } from 'components/nodeeditor/constants';
 import { Types } from 'config/interfaces';
+import { getType } from 'config/typeConfigs';
 import { CallWebhook } from 'flowTypes';
 import { RenderNode } from 'store/flowContext';
 import { NodeEditorSettings, StringEntry } from 'store/nodeEditor';
@@ -56,7 +57,7 @@ export const nodeToState = (settings: NodeEditorSettings): WebhookRouterFormStat
     valid: false
   };
 
-  if (settings.originalNode.ui.type === Types.split_by_webhook) {
+  if (getType(settings.originalNode) === Types.split_by_webhook) {
     const action = getOriginalAction(settings) as CallWebhook;
 
     // add in our headers

--- a/src/config/typeConfigs.ts
+++ b/src/config/typeConfigs.ts
@@ -403,5 +403,10 @@ export const getType = (renderNode: RenderNode): any => {
         return Types.wait_for_video;
     }
   }
+
+  if (renderNode.ui.type === Types.split_by_contact_field && !renderNode.ui.config.operand.name) {
+    return Types.split_by_expression;
+  }
+
   return renderNode.ui.type;
 };

--- a/src/config/typeConfigs.ts
+++ b/src/config/typeConfigs.ts
@@ -404,6 +404,7 @@ export const getType = (renderNode: RenderNode): any => {
     }
   }
 
+  // if we are splitting by field, but don't know the name, force it into split by expression
   if (renderNode.ui.type === Types.split_by_contact_field && !renderNode.ui.config.operand.name) {
     return Types.split_by_expression;
   }

--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -4,6 +4,7 @@ import { DefaultExitNames } from 'components/flow/routers/constants';
 import { getSwitchRouter } from 'components/flow/routers/helpers';
 import { GROUPS_OPERAND } from 'components/nodeeditor/constants';
 import { FlowTypes, Types } from 'config/interfaces';
+import { getType } from 'config/typeConfigs';
 import { getActivity } from 'external';
 import {
   AddLabels,
@@ -93,10 +94,10 @@ export const hasWait = (renderNode: RenderNode): boolean => {
 };
 
 export const hasLoopSplit = (renderNode: RenderNode): boolean => {
+  const type = getType(renderNode);
+
   return (
-    hasWait(renderNode) ||
-    renderNode.ui.type === Types.split_by_expression ||
-    renderNode.ui.type === Types.split_by_subflow
+    hasWait(renderNode) || type === Types.split_by_expression || type === Types.split_by_subflow
   );
 };
 
@@ -507,19 +508,22 @@ export const getFlowComponents = ({ nodes, _ui }: FlowDefinition): FlowComponent
     }
 
     const ui = _ui.nodes[node.uuid];
-    renderNodeMap[node.uuid] = {
+    const renderNode = {
       node,
       ui,
       inboundConnections: {}
     };
+    renderNodeMap[node.uuid] = renderNode;
 
     const resultName = getResultName(node);
     if (resultName) {
       results = addResult(resultName, results, { nodeUUID: node.uuid });
     }
 
+    const type = getType(renderNode);
+
     // if we are split by group, look at our categories for groups
-    if (ui.type === Types.split_by_groups) {
+    if (type === Types.split_by_groups) {
       const router = getSwitchRouter(node);
 
       for (const kase of router.cases) {


### PR DESCRIPTION
* Use `@(urn_parts(urns.tel).path)` when saving scheme splits
* Fallback to split by expression for unnamed schemes

Fixes: #676 
