### PR TITLE
Default confidence to .9 when selecting an intent

### DIFF
--- a/src/components/flow/routers/case/CaseElement.tsx
+++ b/src/components/flow/routers/case/CaseElement.tsx
@@ -200,7 +200,7 @@ export default class CaseElement extends React.Component<CaseElementProps, CaseE
     const updates = validateCase({
       operatorConfig: this.state.operatorConfig,
       intent: selected,
-      confidence: this.state.confidence.value,
+      confidence: this.state.confidence.value || '.9',
       exitName: this.state.categoryName.value,
       exitEdited: this.state.categoryNameEdited,
       classifier: this.props.classifier


### PR DESCRIPTION
Pre-populates the confidence when an intent is configured. Note this isn't straight up default since we don't want validation to kick in until something has been entered.

Fixes: #728 