### PR TITLE
Elide at 5 for asset lists

### DIFF
--- a/src/components/flow/actions/addlabels/AddLabel.test.ts
+++ b/src/components/flow/actions/addlabels/AddLabel.test.ts
@@ -8,7 +8,8 @@ const labels = [
   'New',
   'Feedback',
   'Needs Attention',
-  'Running Out of Plausible Label Names'
+  'Running Out of Plausible Label Names',
+  'But alas, here is another one'
 ];
 
 const baseProps: AddLabels = {

--- a/src/components/flow/actions/addlabels/AddLabels.tsx
+++ b/src/components/flow/actions/addlabels/AddLabels.tsx
@@ -4,7 +4,7 @@ import { fakePropType } from 'config/ConfigProvider';
 import { AddLabels } from 'flowTypes';
 import { AssetType } from 'store/flowContext';
 
-export const MAX_TO_SHOW = 3;
+export const MAX_TO_SHOW = 5;
 
 const AddLabelsComp: React.SFC<AddLabels> = ({ labels }, context: any): JSX.Element => (
   <>

--- a/src/components/flow/actions/addlabels/__snapshots__/AddLabel.test.ts.snap
+++ b/src/components/flow/actions/addlabels/__snapshots__/AddLabel.test.ts.snap
@@ -30,9 +30,29 @@ exports[`AddLabelsComp should display labels on action 1`] = `
     Feedback
   </div>
   <div
+    className="node_asset"
+    key="label-3"
+  >
+    <span
+      className="node_label fe-label"
+    />
+    Needs Attention
+  </div>
+  <div
+    className="node_asset"
+    key="label-4"
+  >
+    <span
+      className="node_label fe-label"
+    />
+    Running Out of Plausible Label Names
+  </div>
+  <div
     key="ellipses"
   >
-    ...
+    +
+    1
+     more
   </div>
 </Fragment>
 `;

--- a/src/components/flow/actions/addurn/AddURN.tsx
+++ b/src/components/flow/actions/addurn/AddURN.tsx
@@ -4,7 +4,7 @@ import { AddURN } from 'flowTypes';
 import { getSchemeObject } from './helpers';
 import i18n from 'config/i18n';
 
-export const MAX_TO_SHOW = 3;
+export const MAX_TO_SHOW = 5;
 
 const AddURNComp: React.SFC<AddURN> = ({ scheme, path }): JSX.Element => {
   const schemeObject = getSchemeObject(scheme);

--- a/src/components/flow/actions/changegroups/ChangeGroups.test.ts
+++ b/src/components/flow/actions/changegroups/ChangeGroups.test.ts
@@ -1,9 +1,9 @@
 import ChangeGroupsComp, {
   contentSpecId,
-  ellipsesText,
   getChangeGroupsMarkup,
   getContentMarkup,
-  getRemoveAllMarkup
+  getRemoveAllMarkup,
+  MAX_TO_SHOW
 } from 'components/flow/actions/changegroups/ChangeGroups';
 import { Types } from 'config/interfaces';
 import { ChangeGroups } from 'flowTypes';
@@ -58,12 +58,11 @@ describe(ChangeGroupsComp.name, () => {
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should limit div to 3 groups, include ellipsesText', () => {
+    it('should limit div to max number of groups', () => {
       const { wrapper } = setup(true, { groups: set(groups) });
       const content = getSpecWrapper(wrapper, contentSpecId);
 
-      expect(content.children().length).toBe(4);
-      expect(content.childAt(3).text()).toBe(ellipsesText);
+      expect(content.children().length).toBe(MAX_TO_SHOW + 1);
       expect(wrapper).toMatchSnapshot();
     });
 

--- a/src/components/flow/actions/changegroups/ChangeGroups.tsx
+++ b/src/components/flow/actions/changegroups/ChangeGroups.tsx
@@ -8,9 +8,8 @@ import { AssetType } from 'store/flowContext';
 export const removeAllSpecId = 'remove_from_all';
 export const contentSpecId = 'content';
 export const removeAllText = 'Remove from all groups';
-export const ellipsesText = '...';
 
-export const MAX_TO_SHOW = 3;
+export const MAX_TO_SHOW = 5;
 export const getRemoveAllMarkup = (
   key = removeAllSpecId,
   specId = removeAllSpecId,

--- a/src/components/flow/actions/changegroups/__snapshots__/ChangeGroups.test.ts.snap
+++ b/src/components/flow/actions/changegroups/__snapshots__/ChangeGroups.test.ts.snap
@@ -28,6 +28,14 @@ exports[`ChangeGroupsComp helpers getChangeGroupsMarkup should return ChangeGrou
     />
     Subscribers
   </div>
+  <div
+    className="node_asset"
+  >
+    <span
+      className="node_group fe-group"
+    />
+    Champions
+  </div>
 </div>
 `;
 
@@ -67,6 +75,14 @@ Array [
     />
     Subscribers
   </div>,
+  <div
+    className="node_asset"
+  >
+    <span
+      className="node_group fe-group"
+    />
+    Champions
+  </div>,
 ]
 `;
 
@@ -78,7 +94,7 @@ exports[`ChangeGroupsComp helpers getRemoveAllMarkup should return remove-all ma
 </div>
 `;
 
-exports[`ChangeGroupsComp render should limit div to 3 groups, include ellipsesText 1`] = `
+exports[`ChangeGroupsComp render should limit div to max number of groups 1`] = `
 <div
   data-spec="content"
 >
@@ -110,9 +126,29 @@ exports[`ChangeGroupsComp render should limit div to 3 groups, include ellipsesT
     Early Adopters
   </div>
   <div
+    className="node_asset"
+    key="afaba971-8943-4dd8-860b-3561ed4f1fe1"
+  >
+    <span
+      className="node_group fe-group"
+    />
+    Testers
+  </div>
+  <div
+    className="node_asset"
+    key="33b28bac-b588-43e4-90de-fda77aeaf7c0"
+  >
+    <span
+      className="node_group fe-group"
+    />
+    Subscribers
+  </div>
+  <div
     key="ellipses"
   >
-    ...
+    +
+    1
+     more
   </div>
 </div>
 `;
@@ -160,6 +196,15 @@ exports[`ChangeGroupsComp render should render group name 1`] = `
       className="node_group fe-group"
     />
     Subscribers
+  </div>
+  <div
+    className="node_asset"
+    key="e0cccbcf-49be-4eef-88a7-ce2150a6d902"
+  >
+    <span
+      className="node_group fe-group"
+    />
+    Champions
   </div>
 </div>
 `;

--- a/src/components/flow/actions/changegroups/__snapshots__/helpers.test.ts.snap
+++ b/src/components/flow/actions/changegroups/__snapshots__/helpers.test.ts.snap
@@ -27,6 +27,11 @@ Array [
     "name": "Subscribers",
     "type": "group",
   },
+  Object {
+    "id": "e0cccbcf-49be-4eef-88a7-ce2150a6d902",
+    "name": "Champions",
+    "type": "group",
+  },
 ]
 `;
 
@@ -51,6 +56,10 @@ Array [
   Object {
     "name": "Subscribers",
     "uuid": "33b28bac-b588-43e4-90de-fda77aeaf7c0",
+  },
+  Object {
+    "name": "Champions",
+    "uuid": "e0cccbcf-49be-4eef-88a7-ce2150a6d902",
   },
 ]
 `;

--- a/src/components/flow/actions/changegroups/addgroups/__snapshots__/AddGroupsForm.test.ts.snap
+++ b/src/components/flow/actions/changegroups/addgroups/__snapshots__/AddGroupsForm.test.ts.snap
@@ -70,6 +70,11 @@ exports[`AddGroupsForm render should render self, children with base props 1`] =
             "name": "Subscribers",
             "type": "group",
           },
+          Object {
+            "id": "e0cccbcf-49be-4eef-88a7-ce2150a6d902",
+            "name": "Champions",
+            "type": "group",
+          },
         ],
       }
     }

--- a/src/components/flow/actions/changegroups/removegroups/__snapshots__/RemoveGroupsForm.test.ts.snap
+++ b/src/components/flow/actions/changegroups/removegroups/__snapshots__/RemoveGroupsForm.test.ts.snap
@@ -65,6 +65,11 @@ exports[`RemoveGroupsForm render should render 1`] = `
               "name": "Subscribers",
               "type": "group",
             },
+            Object {
+              "id": "e0cccbcf-49be-4eef-88a7-ce2150a6d902",
+              "name": "Champions",
+              "type": "group",
+            },
           ],
         }
       }

--- a/src/components/flow/actions/helpers.tsx
+++ b/src/components/flow/actions/helpers.tsx
@@ -43,7 +43,7 @@ export const renderAssetList = (
     if (idx <= max - 1) {
       elements.push(renderAsset(asset, endpoints));
     } else if (idx > max - 1 && elements.length === max) {
-      elements.push(<div key="ellipses">...</div>);
+      elements.push(<div key="ellipses">+{assets.length - max} more</div>);
     }
     return elements;
   }, []);

--- a/src/components/flow/actions/sendbroadcast/SendBroadcast.test.ts
+++ b/src/components/flow/actions/sendbroadcast/SendBroadcast.test.ts
@@ -46,12 +46,13 @@ describe('SendBroadcastComp', () => {
           ],
           groups: [
             { uuid: 'group-1', name: 'Cat Facts' },
-            { uuid: 'group-2', name: 'Cat Fanciers' }
+            { uuid: 'group-2', name: 'Cat Fanciers' },
+            { uuid: 'group-3', name: 'Cat Tattoos' }
           ]
         }
       });
-      expect(wrapper.html()).toContain('...');
-      expect(wrapper.html()).toMatchSnapshot('ellipsized');
+      expect(wrapper.html()).toContain('+1 more');
+      expect(wrapper.html()).toMatchSnapshot('elided');
     });
 
     it('should render placeholder if missing text', () => {

--- a/src/components/flow/actions/sendbroadcast/SendBroadcast.tsx
+++ b/src/components/flow/actions/sendbroadcast/SendBroadcast.tsx
@@ -11,7 +11,7 @@ export const PLACEHOLDER = i18n.t(
   'Send a message to the contact'
 );
 
-const MAX_TO_SHOW = 3;
+const MAX_TO_SHOW = 5;
 
 const SendBroadcastComp: React.SFC<BroadcastMsg> = (
   action: BroadcastMsg,

--- a/src/components/flow/actions/sendbroadcast/__snapshots__/SendBroadcast.test.ts.snap
+++ b/src/components/flow/actions/sendbroadcast/__snapshots__/SendBroadcast.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SendBroadcastComp render should render a long list of both: ellipsized 1`] = `"<div class=\\"node\\"><div class=\\"to\\"><div class=\\"node_asset\\"><span class=\\"node_group fe-group\\"></span>Cat Facts</div><div class=\\"node_asset\\"><span class=\\"node_group fe-group\\"></span>Cat Fanciers</div><div class=\\"node_asset\\">Norbert Kwizera</div><div>...</div></div><div class=\\"message\\"><div class=\\"line\\">Hello World</div></div></div>"`;
+exports[`SendBroadcastComp render should render a long list of both: elided 1`] = `"<div class=\\"node\\"><div class=\\"to\\"><div class=\\"node_asset\\"><span class=\\"node_group fe-group\\"></span>Cat Facts</div><div class=\\"node_asset\\"><span class=\\"node_group fe-group\\"></span>Cat Fanciers</div><div class=\\"node_asset\\"><span class=\\"node_group fe-group\\"></span>Cat Tattoos</div><div class=\\"node_asset\\">Norbert Kwizera</div><div class=\\"node_asset\\">Kellan Alexander</div><div>+1 more</div></div><div class=\\"message\\"><div class=\\"line\\">Hello World</div></div></div>"`;
 
 exports[`SendBroadcastComp render should render placeholder if missing text: placeholder text 1`] = `"<div class=\\"placeholder\\">Send a message to the contact</div>"`;
 

--- a/src/components/flow/actions/startsession/StartSession.test.tsx
+++ b/src/components/flow/actions/startsession/StartSession.test.tsx
@@ -20,13 +20,15 @@ describe('StartSessionComp', () => {
           contacts={[
             { uuid: 'contact-1', name: 'Norbert Kwizera' },
             { uuid: 'contact-2', name: 'Kellan Alexander' },
-            { uuid: 'contact-3', name: 'Rowan Seymour' }
+            { uuid: 'contact-3', name: 'Rowan Seymour' },
+            { uuid: 'contact-4', name: 'Leah Burgerbuns' },
+            { uuid: 'contact-5', name: 'Nic Pottier' }
           ]}
         />
       );
 
       expect(baseElement).toMatchSnapshot();
-      getByText('...');
+      getByText('+1 more');
     });
 
     it('should render creating a new contact', () => {

--- a/src/components/flow/actions/startsession/StartSession.tsx
+++ b/src/components/flow/actions/startsession/StartSession.tsx
@@ -6,7 +6,7 @@ import { AssetType } from 'store/flowContext';
 
 import styles from './StartSession.module.scss';
 
-const MAX_TO_SHOW = 3;
+const MAX_TO_SHOW = 5;
 
 export const StartSessionComp: React.SFC<StartSession> = (
   action: StartSession,

--- a/src/components/flow/actions/startsession/__snapshots__/StartSession.test.tsx.snap
+++ b/src/components/flow/actions/startsession/__snapshots__/StartSession.test.tsx.snap
@@ -27,8 +27,20 @@ exports[`StartSessionComp render should render a long list of both contacts and 
         >
           Kellan Alexander
         </div>
+        <div
+          class="node_asset"
+        >
+          Rowan Seymour
+        </div>
+        <div
+          class="node_asset"
+        >
+          Leah Burgerbuns
+        </div>
         <div>
-          ...
+          +
+          1
+           more
         </div>
       </div>
       <div

--- a/src/components/flow/routers/groups/__snapshots__/GroupsRouterForm.test.ts.snap
+++ b/src/components/flow/routers/groups/__snapshots__/GroupsRouterForm.test.ts.snap
@@ -40,6 +40,14 @@ Object {
 }
 `;
 
+exports[`GroupsRouterForm helpers extractGroups should extract groups from the exits of a groupsRouter node 6`] = `
+Object {
+  "id": "e0cccbcf-49be-4eef-88a7-ce2150a6d902",
+  "name": "Champions",
+  "type": "group",
+}
+`;
+
 exports[`GroupsRouterForm render should render 1`] = `
 <Dialog
   buttons={
@@ -103,6 +111,11 @@ exports[`GroupsRouterForm render should render 1`] = `
           Object {
             "id": "33b28bac-b588-43e4-90de-fda77aeaf7c0",
             "name": "Subscribers",
+            "type": "group",
+          },
+          Object {
+            "id": "e0cccbcf-49be-4eef-88a7-ce2150a6d902",
+            "name": "Champions",
             "type": "group",
           },
         ],
@@ -170,7 +183,7 @@ Array [
         },
         Object {
           "destination_uuid": null,
-          "uuid": "132de855-4042-4dc1-a18f-cc2e6a8f790a",
+          "uuid": "2dc85899-0577-4f1b-a620-f12094e34b5e",
         },
       ],
       "router": Object {
@@ -192,12 +205,12 @@ Array [
             "uuid": "1dce2b34-9aab-4e20-81c4-3f0408dcb671",
           },
           Object {
-            "exit_uuid": "132de855-4042-4dc1-a18f-cc2e6a8f790a",
+            "exit_uuid": "2dc85899-0577-4f1b-a620-f12094e34b5e",
             "name": "Other",
-            "uuid": "6c22884b-0e35-4206-982e-18320691eda9",
+            "uuid": "0c8c9239-9b59-473a-a229-d8a9693be270",
           },
         ],
-        "default_category_uuid": "6c22884b-0e35-4206-982e-18320691eda9",
+        "default_category_uuid": "0c8c9239-9b59-473a-a229-d8a9693be270",
         "operand": "@contact.groups",
         "result_name": "My Group Result",
         "type": "switch",

--- a/src/test/assets/groups.json
+++ b/src/test/assets/groups.json
@@ -19,6 +19,10 @@
     {
       "name": "Subscribers",
       "uuid": "33b28bac-b588-43e4-90de-fda77aeaf7c0"
+    },
+    {
+      "name": "Champions",
+      "uuid": "e0cccbcf-49be-4eef-88a7-ce2150a6d902"
     }
   ]
 }


### PR DESCRIPTION
Adds `+n more` for any over 5 instead of `...`

Fixes: #775 