### PR TITLE
Completion fixes

### DIFF
--- a/src/components/flow/actions/sendmsg/SendMsgForm.tsx
+++ b/src/components/flow/actions/sendmsg/SendMsgForm.tsx
@@ -142,6 +142,11 @@ export default class SendMsgForm extends React.Component<ActionFormProps, SendMs
   }
 
   private handleSave(): void {
+    // don't continue if our message already has errors
+    if (hasErrors(this.state.message)) {
+      return;
+    }
+
     // make sure we validate untouched text fields and contact fields
     let valid = this.handleMessageUpdate(this.state.message.value, null, true);
 

--- a/src/components/form/textinput/ExcellentParser.ts
+++ b/src/components/form/textinput/ExcellentParser.ts
@@ -228,8 +228,13 @@ export default class ExcellentParser {
     const re = /((parent|child\.)*contact\.)*fields\.([a-z0-9_]+)/g;
     const expressions = this.findExpressions(text);
     for (const expression of expressions) {
+      if (expression.text.indexOf('webhook') > -1) {
+        continue;
+      }
+
       let match;
       // tslint:disable-next-line:no-conditional-assignment
+
       while ((match = re.exec(expression.text))) {
         (fields as any)[match[3]] = true;
       }

--- a/src/components/form/textinput/TextInputElement.test.ts
+++ b/src/components/form/textinput/TextInputElement.test.ts
@@ -11,6 +11,7 @@ import { AssetType } from 'store/flowContext';
 import * as completionSchema from 'test/assets/completion.json';
 import functions from 'test/assets/functions.json';
 import { composeComponentTestUtils } from 'testUtils';
+import { dump } from 'utils';
 
 // we need to track where our cursor would be to simulate properly
 let mockCursor = 0;

--- a/src/utils/completion.ts
+++ b/src/utils/completion.ts
@@ -26,8 +26,8 @@ export interface CompletionSchema {
 
 export const getFunctions = (functions: CompletionOption[], query: string): CompletionOption[] => {
   return functions.filter((option: CompletionOption) => {
-    if (query && option.signature) {
-      return option.signature.indexOf(query.toLowerCase()) === 0;
+    if (option.signature) {
+      return option.signature.indexOf((query || '').toLowerCase()) === 0;
     }
     return false;
   });
@@ -72,10 +72,8 @@ export const getCompletions = (
               }))
             : [];
         } else {
-          // eslint-disable-next-line
-          currentProps = currentProps.filter((prop: CompletionProperty) =>
-            prop.key.startsWith(part.toLowerCase())
-          );
+          // if not type found, hide completion
+          currentProps = [];
           break;
         }
       } else {

--- a/src/utils/completion.ts
+++ b/src/utils/completion.ts
@@ -26,8 +26,8 @@ export interface CompletionSchema {
 
 export const getFunctions = (functions: CompletionOption[], query: string): CompletionOption[] => {
   return functions.filter((option: CompletionOption) => {
-    if (option.signature) {
-      return option.signature.indexOf(query) === 0;
+    if (query && option.signature) {
+      return option.signature.indexOf(query.toLowerCase()) === 0;
     }
     return false;
   });


### PR DESCRIPTION
- Uppercase matching for functions
- Hide completion when drilling into webhooks
- Don't validate for missing fields if the expression is a webhook

Fixes: #807 
Fixes: #812 
Fixes: #813 