### PR TITLE
Switch to relative dates on recent messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "lint-staged": "8.1.7",
     "local-storage": "1.4.2",
     "lodash.clonedeep": "4.5.0",
+    "moment": "2.24.0",
     "netlify-lambda": "^1.4.9",
     "node-sass": "4.13.1",
     "prettier": "1.18.2",

--- a/src/components/flow/exit/Exit.module.scss
+++ b/src/components/flow/exit/Exit.module.scss
@@ -129,7 +129,7 @@
 
 .recent_messages {
   position: absolute;
-  min-width: 150px;
+  min-width: 200px;
   margin-top: 40px;
   z-index: $z_recent_messages;
   background: $light_gray_2;

--- a/src/components/flow/exit/Exit.test.ts
+++ b/src/components/flow/exit/Exit.test.ts
@@ -40,8 +40,8 @@ describe(ExitComp.name, () => {
     instance.setState(
       {
         recentMessages: [
-          { text: 'Hi Mom!', sent: 'Apr 1, 2019' },
-          { text: 'Hi Dad!', sent: 'Apr 2, 2019' }
+          { text: 'Hi Mom!', sent: new Date().toUTCString() },
+          { text: 'Hi Dad!', sent: new Date().toUTCString() }
         ]
       },
       () => {

--- a/src/components/flow/exit/Exit.tsx
+++ b/src/components/flow/exit/Exit.tsx
@@ -16,6 +16,7 @@ import AppState from 'store/state';
 import { DisconnectExit, disconnectExit, DispatchWithState } from 'store/thunks';
 import { createClickHandler, getLocalization, renderIf } from 'utils';
 
+import * as moment from 'moment';
 import styles from './Exit.module.scss';
 
 export interface ExitPassedProps {
@@ -287,7 +288,7 @@ export class ExitComp extends React.PureComponent<ExitProps, ExitState> {
           {recentMessages.map((recentMessage: RecentMessage, idx: number) => (
             <div key={'recent_' + idx} className={styles.message}>
               <div className={styles.text}>{recentMessage.text}</div>
-              <div className={styles.sent}>{recentMessage.sent.toLocaleString()}</div>
+              <div className={styles.sent}>{moment.utc(recentMessage.sent).fromNow()}</div>
             </div>
           ))}
           {this.state.recentMessages === null ? (

--- a/src/components/flow/exit/__snapshots__/Exit.test.ts.snap
+++ b/src/components/flow/exit/__snapshots__/Exit.test.ts.snap
@@ -156,7 +156,7 @@ exports[`ExitComp shows recent messages 1`] = `
         <div
           className="sent"
         >
-          Apr 1, 2019
+          a few seconds ago
         </div>
       </div>
       <div
@@ -171,7 +171,7 @@ exports[`ExitComp shows recent messages 1`] = `
         <div
           className="sent"
         >
-          Apr 2, 2019
+          a few seconds ago
         </div>
       </div>
     </div>

--- a/src/components/simulator/Simulator.tsx
+++ b/src/components/simulator/Simulator.tsx
@@ -234,7 +234,10 @@ export class Simulator extends React.Component<SimulatorProps, SimulatorState> {
         }
       }
 
-      const simulatedMessages = this.props.activity.recentMessages || {};
+      // if we are resetting, clear our recent messages
+      const simulatedMessages = this.state.session.input
+        ? this.props.activity.recentMessages || {}
+        : {};
 
       for (const key in recentMessages) {
         let messages = simulatedMessages[key] || [];
@@ -294,7 +297,7 @@ export class Simulator extends React.Component<SimulatorProps, SimulatorState> {
             if (fromUUID && toUUID) {
               const key = `${fromUUID}:${toUUID}`;
               const msg: RecentMessage = {
-                sent: new Date(event.created_on),
+                sent: event.created_on,
                 text: event.msg.text
               };
 

--- a/src/external/index.ts
+++ b/src/external/index.ts
@@ -90,7 +90,7 @@ export const getRecentMessages = (
       .then((response: AxiosResponse) => {
         const recentMessages: RecentMessage[] = [];
         for (const row of response.data) {
-          recentMessages.push({ text: row.text, sent: new Date(row.sent) });
+          recentMessages.push({ text: row.text, sent: row.sent });
         }
 
         resolve(response.data as RecentMessage[]);

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -28,7 +28,7 @@ export interface Activity {
 }
 
 export interface RecentMessage {
-  sent: Date;
+  sent: string;
   text: string;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8365,6 +8365,11 @@ mocha@^5.2.0:
     mkdirp "0.5.1"
     supports-color "5.4.0"
 
+moment@2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 moo@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"


### PR DESCRIPTION
~16k bundle hit to leverage moment so these can be localizable.

Fixes: #784 

<img width="320" alt="Screen Shot 2020-02-14 at 9 59 31 AM" src="https://user-images.githubusercontent.com/211652/74555524-bac89500-4f10-11ea-9e87-64de404bce10.png">
