### PR TITLE
Hide has_value for new nodes

### DIFF
--- a/src/components/flow/routers/case/__snapshots__/CaseElement.test.tsx.snap
+++ b/src/components/flow/routers/case/__snapshots__/CaseElement.test.tsx.snap
@@ -136,11 +136,6 @@ exports[`CaseElement operator changes should handle updates 1`] = `
               has ward
             </option>
             <option
-              value="has_value"
-            >
-              is not empty
-            </option>
-            <option
               value="has_pattern"
             >
               matches regex
@@ -341,11 +336,6 @@ exports[`CaseElement operator changes should should set arguments for numeric ra
               value="has_ward"
             >
               has ward
-            </option>
-            <option
-              value="has_value"
-            >
-              is not empty
             </option>
             <option
               value="has_pattern"
@@ -631,11 +621,6 @@ exports[`CaseElement operator changes shouldnt update exit if it has been edited
               has ward
             </option>
             <option
-              value="has_value"
-            >
-              is not empty
-            </option>
-            <option
               value="has_pattern"
             >
               matches regex
@@ -838,11 +823,6 @@ exports[`CaseElement render renders no argument rules 1`] = `
               has ward
             </option>
             <option
-              value="has_value"
-            >
-              is not empty
-            </option>
-            <option
               value="has_pattern"
             >
               matches regex
@@ -1043,11 +1023,6 @@ exports[`CaseElement render should render empty case 1`] = `
               value="has_ward"
             >
               has ward
-            </option>
-            <option
-              value="has_value"
-            >
-              is not empty
             </option>
             <option
               value="has_pattern"
@@ -1291,11 +1266,6 @@ exports[`CaseElement update handles argument change 1`] = `
               has ward
             </option>
             <option
-              value="has_value"
-            >
-              is not empty
-            </option>
-            <option
               value="has_pattern"
             >
               matches regex
@@ -1535,11 +1505,6 @@ exports[`CaseElement update handles multiple argument change 1`] = `
               value="has_ward"
             >
               has ward
-            </option>
-            <option
-              value="has_value"
-            >
-              is not empty
             </option>
             <option
               value="has_pattern"

--- a/src/components/flow/routers/caselist/__snapshots__/CaseList.test.tsx.snap
+++ b/src/components/flow/routers/caselist/__snapshots__/CaseList.test.tsx.snap
@@ -142,11 +142,6 @@ exports[`CaseList render should render empty list 1`] = `
                   has ward
                 </option>
                 <option
-                  value="has_value"
-                >
-                  is not empty
-                </option>
-                <option
                   value="has_pattern"
                 >
                   matches regex
@@ -396,11 +391,6 @@ exports[`CaseList render should render list of cases 1`] = `
                   has ward
                 </option>
                 <option
-                  value="has_value"
-                >
-                  is not empty
-                </option>
-                <option
                   value="has_pattern"
                 >
                   matches regex
@@ -639,11 +629,6 @@ exports[`CaseList render should render list of cases 1`] = `
                   has ward
                 </option>
                 <option
-                  value="has_value"
-                >
-                  is not empty
-                </option>
-                <option
                   value="has_pattern"
                 >
                   matches regex
@@ -880,11 +865,6 @@ exports[`CaseList render should render list of cases 1`] = `
                   value="has_ward"
                 >
                   has ward
-                </option>
-                <option
-                  value="has_value"
-                >
-                  is not empty
                 </option>
                 <option
                   value="has_pattern"
@@ -1136,11 +1116,6 @@ exports[`CaseList updates should remove cases 1`] = `
                   has ward
                 </option>
                 <option
-                  value="has_value"
-                >
-                  is not empty
-                </option>
-                <option
                   value="has_pattern"
                 >
                   matches regex
@@ -1377,11 +1352,6 @@ exports[`CaseList updates should remove cases 1`] = `
                   value="has_ward"
                 >
                   has ward
-                </option>
-                <option
-                  value="has_value"
-                >
-                  is not empty
                 </option>
                 <option
                   value="has_pattern"
@@ -1633,11 +1603,6 @@ exports[`CaseList updates should update cases 1`] = `
                   has ward
                 </option>
                 <option
-                  value="has_value"
-                >
-                  is not empty
-                </option>
-                <option
                   value="has_pattern"
                 >
                   matches regex
@@ -1876,11 +1841,6 @@ exports[`CaseList updates should update cases 1`] = `
                   has ward
                 </option>
                 <option
-                  value="has_value"
-                >
-                  is not empty
-                </option>
-                <option
                   value="has_pattern"
                 >
                   matches regex
@@ -2117,11 +2077,6 @@ exports[`CaseList updates should update cases 1`] = `
                   value="has_ward"
                 >
                   has ward
-                </option>
-                <option
-                  value="has_value"
-                >
-                  is not empty
                 </option>
                 <option
                   value="has_pattern"

--- a/src/components/flow/routers/result/__snapshots__/ResultRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/result/__snapshots__/ResultRouterForm.test.tsx.snap
@@ -448,11 +448,6 @@ exports[`ResultRouterForm should render 1`] = `
                       has ward
                     </option>
                     <option
-                      value="has_value"
-                    >
-                      is not empty
-                    </option>
-                    <option
                       value="has_pattern"
                     >
                       matches regex
@@ -1108,11 +1103,6 @@ exports[`ResultRouterForm should show delimit options 1`] = `
                       value="has_ward"
                     >
                       has ward
-                    </option>
-                    <option
-                      value="has_value"
-                    >
-                      is not empty
                     </option>
                     <option
                       value="has_pattern"

--- a/src/config/__snapshots__/operatorConfigs.test.ts.snap
+++ b/src/config/__snapshots__/operatorConfigs.test.ts.snap
@@ -200,6 +200,9 @@ Array [
     "operands": 0,
     "type": "has_value",
     "verboseName": "is not empty",
+    "visibility": Array [
+      "-",
+    ],
   },
   Object {
     "operands": 1,
@@ -426,6 +429,9 @@ Object {
     "operands": 0,
     "type": "has_value",
     "verboseName": "is not empty",
+    "visibility": Array [
+      "-",
+    ],
   },
   "has_ward": Object {
     "categoryName": "Has Ward",

--- a/src/config/operatorConfigs.ts
+++ b/src/config/operatorConfigs.ts
@@ -175,7 +175,8 @@ export const operatorConfigList: Operator[] = [
     type: Operators.has_value,
     verboseName: i18n.t('operators.has_value', 'is not empty'),
     operands: 0,
-    categoryName: i18n.t('operators.has_value_category', 'Not Empty')
+    categoryName: i18n.t('operators.has_value_category', 'Not Empty'),
+    visibility: HIDDEN
   },
   {
     type: Operators.has_pattern,


### PR DESCRIPTION
Fixes: #725 

Removes has_value (Not Empty) rule from list for new nodes, but allows existing nodes that use it to continue to do so.