### PR TITLE
More performance updates, add horizontal scrolling

### DIFF
--- a/src/components/__snapshots__/index.test.ts.snap
+++ b/src/components/__snapshots__/index.test.ts.snap
@@ -67,6 +67,9 @@ exports[`Root render should apply translating style if passed a truthy translati
       <div
         id="portal-root"
       />
+      <div
+        id="canvas-portal"
+      />
     </div>
   </div>
 </PageVisibility>
@@ -109,6 +112,9 @@ exports[`Root render should render flow if passed a definition, language 1`] = `
       <div
         id="portal-root"
       />
+      <div
+        id="canvas-portal"
+      />
     </div>
   </div>
 </PageVisibility>
@@ -149,6 +155,9 @@ exports[`Root render should render self, children with required props 1`] = `
       />
       <div
         id="portal-root"
+      />
+      <div
+        id="canvas-portal"
       />
     </div>
   </div>

--- a/src/components/canvas/Canvas.module.scss
+++ b/src/components/canvas/Canvas.module.scss
@@ -1,44 +1,87 @@
-@import "variables.module.scss";
+@import 'variables.module.scss';
 
 $background_offset: ($grid_size / 2) + ($node_padding) + px;
 
 .canvas_container {
-  position: relative;
-  padding: 20px;
-  padding-right: 0;
+  overflow-x: scroll;
+  width: 100%;
+}
+
+.canvas_background {
+  padding-top: 60px;
+  padding-left: 20px;
+  margin-right: -20px;
+
   background-color: #f9f9f9;
-  background-position: $background_offset $background_offset;
-  $color_1: rgba(61, 177, 255, 0.15);
+  background-position: 13px 13px;
   background-image: linear-gradient(
       0deg,
       transparent 24%,
-      $color_1 25%,
-      $color_1 26%,
+      rgba(61, 177, 255, 0.15) 25%,
+      rgba(61, 177, 255, 0.15) 26%,
       transparent 27%,
       transparent 74%,
-      $color_1 75%,
-      $color_1 76%,
+      rgba(61, 177, 255, 0.15) 75%,
+      rgba(61, 177, 255, 0.15) 76%,
       transparent 77%,
       transparent
     ),
     linear-gradient(
       90deg,
       transparent 24%,
-      $color_1 25%,
-      $color_1 26%,
+      rgba(61, 177, 255, 0.15) 25%,
+      rgba(61, 177, 255, 0.15) 26%,
       transparent 27%,
       transparent 74%,
-      $color_1 75%,
-      $color_1 76%,
+      rgba(61, 177, 255, 0.15) 75%,
+      rgba(61, 177, 255, 0.15) 76%,
       transparent 77%,
       transparent
     );
-  background-size: ($grid_size * 2) + px ($grid_size * 2) + px;
+  background-size: 40px 40px;
 }
-
 .canvas {
   position: relative;
   width: 100%;
+
+  // margin-top: -40px;
+}
+
+.canvas:after {
+  content: '';
+  position: absolute;
+  top: -60px;
+  bottom: 0;
+  width: 400%;
+  left: 100%;
+
+  background-color: #f9f9f9;
+  background-position: 13px 13px;
+  background-image: linear-gradient(
+      0deg,
+      transparent 24%,
+      rgba(61, 177, 255, 0.15) 25%,
+      rgba(61, 177, 255, 0.15) 26%,
+      transparent 27%,
+      transparent 74%,
+      rgba(61, 177, 255, 0.15) 75%,
+      rgba(61, 177, 255, 0.15) 76%,
+      transparent 77%,
+      transparent
+    ),
+    linear-gradient(
+      90deg,
+      transparent 24%,
+      rgba(61, 177, 255, 0.15) 25%,
+      rgba(61, 177, 255, 0.15) 26%,
+      transparent 27%,
+      transparent 74%,
+      rgba(61, 177, 255, 0.15) 75%,
+      rgba(61, 177, 255, 0.15) 76%,
+      transparent 77%,
+      transparent
+    );
+  background-size: 40px 40px;
 }
 
 .drag_selection {

--- a/src/components/canvas/Canvas.test.tsx
+++ b/src/components/canvas/Canvas.test.tsx
@@ -14,7 +14,11 @@ const baseProps: CanvasProps = {
   onUpdatePositions: jest.fn(),
   mergeEditorState: jest.fn(),
   onRemoveNodes: jest.fn(),
-  draggables: []
+  onDoubleClick: jest.fn(),
+  onLoaded: jest.fn(),
+  draggables: [],
+  newDragElement: <div></div>,
+  mutable: true
 };
 
 describe(Canvas.name, () => {
@@ -25,9 +29,10 @@ describe(Canvas.name, () => {
 
   it('initializes the height to the lowest draggable', () => {
     const lowest: CanvasDraggableProps = {
-      ele,
+      elementCreator: jest.fn(),
       uuid: createUUID(),
-      position: { top: 1200, left: 100, bottom: 1290, right: 300 }
+      position: { top: 1200, left: 100, bottom: 1290, right: 300 },
+      idx: 0
     };
     const { baseElement, getByTestId } = render(<Canvas {...baseProps} draggables={[lowest]} />);
     expect(getByTestId('canvas').style.height).toBe(1290 + CANVAS_PADDING + 'px');
@@ -37,9 +42,10 @@ describe(Canvas.name, () => {
   it('adjusts the height when updating dimensions', () => {
     const uuid = createUUID();
     const lowest: CanvasDraggableProps = {
-      ele,
+      elementCreator: jest.fn(),
       uuid,
-      position: { top: 1200, left: 100, right: 200, bottom: 1400 }
+      position: { top: 1200, left: 100, right: 200, bottom: 1400 },
+      idx: 0
     };
 
     const { baseElement, getByTestId } = render(<Canvas {...baseProps} draggables={[lowest]} />);
@@ -51,15 +57,17 @@ describe(Canvas.name, () => {
     jest.useFakeTimers();
 
     const first: CanvasDraggableProps = {
-      ele,
+      elementCreator: jest.fn(),
       uuid: createUUID(),
-      position: { top: 100, bottom: 200, left: 100, right: 200 }
+      position: { top: 100, bottom: 200, left: 100, right: 200 },
+      idx: 0
     };
 
     const second: CanvasDraggableProps = {
-      ele,
+      elementCreator: jest.fn(),
       uuid: createUUID(),
-      position: { top: 150, left: 100, bottom: 250, right: 200 }
+      position: { top: 150, left: 100, bottom: 250, right: 200 },
+      idx: 0
     };
 
     const onDragging = jest.fn();

--- a/src/components/canvas/Canvas.tsx
+++ b/src/components/canvas/Canvas.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { CanvasPositions, DragSelection } from 'store/editor';
 import { addPosition } from 'store/helpers';
 import { MergeEditorState } from 'store/thunks';
-import { COLLISION_FUDGE, snapPositionToGrid, throttle } from 'utils';
+import { COLLISION_FUDGE, snapPositionToGrid, throttle, snapToGrid } from 'utils';
 
 import styles from './Canvas.module.scss';
 
@@ -19,11 +19,14 @@ export interface CanvasProps {
   uuid: string;
   dragActive: boolean;
   draggingNew: boolean;
+  newDragElement: JSX.Element;
   draggables: CanvasDraggableProps[];
   mutable: boolean;
+  onLoaded: () => void;
   onDragging: (draggedUUIDs: string[]) => void;
   onUpdatePositions: (positions: CanvasPositions) => void;
   onRemoveNodes: (nodeUUIDs: string[]) => void;
+  onDoubleClick: (position: FlowPosition) => void;
   mergeEditorState: MergeEditorState;
 }
 
@@ -40,7 +43,6 @@ interface CanvasState {
 
 export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
   private ele!: HTMLDivElement;
-  private parentOffset!: FlowPosition;
   private isScrolling: any;
 
   private reflowTimeout: any;
@@ -52,7 +54,7 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
   // did we just select something
   private justSelected = false;
 
-  private onDragThrottled: (uuids: string[]) => void = throttle(this.props.onDragging, 10);
+  private onDragThrottled: (uuids: string[]) => void = throttle(this.props.onDragging, 300);
   private onMouseThrottled: (event: any) => void = throttle(this.handleMouseMove.bind(this), 10);
 
   constructor(props: CanvasProps) {
@@ -80,7 +82,7 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
     };
 
     bindCallbacks(this, {
-      include: [/^handle/, /^render/]
+      include: [/^handle/, /^render/, /^mark/, /^do/, /^ensure/]
     });
   }
 
@@ -90,15 +92,11 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
   }
 
   public componentDidMount(): void {
-    let offset = { left: 0, top: 0 };
     /* istanbul ignore next */
-    if (this.ele) {
-      offset = this.ele.getBoundingClientRect();
-    }
-    this.parentOffset = { left: offset.left, top: offset.top + window.scrollY };
-
     window.addEventListener('resize', this.handleWindowResize);
     document.addEventListener('keydown', this.handleKeyDown);
+
+    this.props.onLoaded();
   }
 
   private handleKeyDown(event: any): void {
@@ -115,9 +113,11 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
     document.removeEventListener('keydown', this.handleKeyDown);
   }
 
-  public componentDidUpdate(prevProps: CanvasProps): void {
+  public componentDidUpdate(prevProps: CanvasProps, prevState: CanvasState): void {
+    // traceUpdate(this, prevProps, prevState);
+
     let updated = false;
-    let updatedPositions = this.state.positions;
+    let updatedPositions = { ...this.state.positions };
 
     // are we being given something new
     this.props.draggables.forEach((draggable: CanvasDraggableProps) => {
@@ -152,6 +152,7 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
       const top = Math.min(drag.startY, drag.currentY);
       const width = Math.max(drag.startX, drag.currentX) - left;
       const height = Math.max(drag.startY, drag.currentY) - top;
+
       if (this.state.dragSelection && this.state.dragSelection.startX) {
         return <div className={styles.drag_selection} style={{ left, top, width, height }} />;
       }
@@ -165,7 +166,7 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
     if (event.nativeEvent.which === 3) {
       return false;
     }
-    return (event.target as any).id === this.state.uuid;
+    return (event.target as any).id === 'canvas';
   }
 
   private handleMouseDown(event: React.MouseEvent<HTMLDivElement>): void {
@@ -178,15 +179,15 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
       return;
     }
 
+    const offset = this.ele.getBoundingClientRect();
+
     this.justSelected = false;
     if (this.isClickOnCanvas(event)) {
+      const startX = event.pageX - offset.left;
+      const startY = event.pageY - offset.top - window.scrollY;
+
       this.setState({
-        dragSelection: {
-          startX: event.pageX - this.parentOffset.left,
-          startY: event.pageY - this.parentOffset.top,
-          currentX: event.pageX - this.parentOffset.left,
-          currentY: event.pageY - this.parentOffset.top
-        }
+        dragSelection: { startX, startY, currentX: startX, currentY: startY }
       });
     }
   }
@@ -200,6 +201,9 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
       this.lastX = event.pageX;
       this.lastY = event.pageY;
       this.updateStateWithScroll(event.clientY, event.pageY);
+      if (this.state.dragUUID) {
+        this.updatePositions(event.pageX, event.pageY, event.clientY, false);
+      }
       return;
     }
 
@@ -219,12 +223,14 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
           bottom
         });
 
+        const offset = this.ele.getBoundingClientRect();
+
         this.setState({
           dragSelection: {
             startX: drag.startX,
             startY: drag.startY,
-            currentX: event.pageX - this.parentOffset.left,
-            currentY: event.pageY - this.parentOffset.top
+            currentX: event.pageX - offset.left,
+            currentY: event.pageY - offset.top - window.scrollY
           }
         });
 
@@ -303,21 +309,21 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
   }
 
   public handleUpdateDimensions(uuid: string, dimensions: Dimensions): void {
-    let pos = this.state.positions[uuid];
-    if (!pos) {
-      pos = this.props.draggables.find((item: CanvasDraggableProps) => item.uuid === uuid)!
-        .position;
-    }
+    if (dimensions.width && dimensions.height) {
+      let pos = this.state.positions[uuid];
+      if (!pos) {
+        pos = this.props.draggables.find((item: CanvasDraggableProps) => item.uuid === uuid)!
+          .position;
+      }
 
-    const newPosition = {
-      left: pos.left,
-      top: pos.top,
-      right: pos.left + dimensions.width,
-      bottom: pos.top + dimensions.height
-    };
+      const newPosition = {
+        left: pos.left,
+        top: pos.top,
+        right: pos.left + dimensions.width,
+        bottom: pos.top + dimensions.height
+      };
 
-    if (newPosition.bottom !== pos.bottom || newPosition.right !== pos.right) {
-      if (newPosition.right !== pos.right || newPosition.bottom !== pos.bottom) {
+      if (newPosition.bottom !== pos.bottom || newPosition.right !== pos.right) {
         this.setState((prevState: CanvasState) => {
           const newPositions = mutate(prevState.positions, {
             $merge: {
@@ -329,15 +335,30 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
             positions: newPositions,
             height: Math.max(newPosition.bottom + CANVAS_PADDING, prevState.height)
           };
-        });
-
-        this.markReflow();
+        }, this.markReflow);
       }
     }
   }
 
+  public ensureCanvasHeight() {
+    let height = this.state.height;
+    Object.keys(this.state.positions).forEach(uuid => {
+      const bottom = this.state.positions[uuid].bottom + CANVAS_PADDING;
+      if (bottom > height) {
+        height = bottom;
+      }
+    });
+
+    if (height > this.state.height) {
+      this.setState({ height });
+    }
+  }
+
   public doReflow(): void {
-    const { positions, changed } = reflow(this.state.positions, COLLISION_FUDGE);
+    const reflowPositions = { ...this.state.positions };
+    delete reflowPositions[this.state.dragUUID];
+    const { positions, changed } = reflow(reflowPositions, COLLISION_FUDGE);
+
     if (changed) {
       this.setState({ positions });
 
@@ -417,12 +438,13 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
         ? this.state.selected[dragUUID]
         : this.state.positions[dragUUID];
 
+      const offset = this.ele.getBoundingClientRect();
+
       if (this.state.dragDownPosition) {
-        const xd =
-          pageX - this.parentOffset.left - this.state.dragDownPosition.left - startPosition.left;
+        const xd = pageX - offset.left - this.state.dragDownPosition.left - startPosition.left;
 
         const yd =
-          pageY - this.parentOffset.top - this.state.dragDownPosition.top - startPosition.top;
+          pageY - offset.top - this.state.dragDownPosition.top - startPosition.top - window.scrollY;
 
         let lowestNode: number | undefined = 0;
         if (this.props.dragActive) {
@@ -451,7 +473,11 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
             positions: newPositions
           });
 
-          this.onDragThrottled(uuids);
+          if (uuids.length <= 5) {
+            this.props.onDragging(uuids);
+          } else {
+            this.onDragThrottled(uuids);
+          }
         } else {
           if (Math.abs(xd) + Math.abs(yd) > DRAG_THRESHOLD) {
             let selected = this.state.selected;
@@ -471,11 +497,13 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
   }
 
   private handleDragStart(uuid: string, position: FlowPosition): void {
+    const offset = this.ele.getBoundingClientRect();
+
     this.setState({
       dragUUID: uuid,
       dragDownPosition: {
-        left: position.left - this.parentOffset.left,
-        top: position.top - this.parentOffset.top
+        left: position.left - offset.left,
+        top: position.top - offset.top - window.scrollY
       }
     });
   }
@@ -507,41 +535,61 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
     });
   }
 
+  private handleAnimated(uuid: string): void {
+    this.props.onDragging([uuid]);
+  }
+
+  private handleDoubleClick(event: React.MouseEvent<HTMLDivElement>): void {
+    if (this.isClickOnCanvas(event)) {
+      const offset = this.ele.getBoundingClientRect();
+      this.props.onDoubleClick(
+        snapToGrid(event.pageX - offset.left, event.pageY - offset.top - window.scrollY)
+      );
+    }
+  }
+
   public render(): JSX.Element {
     return (
-      <div className={styles.canvas_container}>
-        <div
-          data-testid="canvas"
-          style={{ height: this.state.height }}
-          id={this.state.uuid}
-          ref={(ele: HTMLDivElement) => {
-            this.ele = ele;
-          }}
-          className={styles.canvas}
-          onMouseDown={this.handleMouseDown}
-          onMouseMove={this.onMouseThrottled}
-          onMouseUp={this.handleMouseUpCapture}
-        >
-          {this.props.draggables.map((draggable: CanvasDraggableProps) => {
-            const pos = this.state.positions[draggable.uuid] || draggable.position;
-            return (
-              <CanvasDraggable
-                onAnimated={(uuid: string) => {
-                  this.props.onDragging([uuid]);
-                }}
-                key={'draggable_' + draggable.uuid}
-                uuid={draggable.uuid}
-                updateDimensions={this.handleUpdateDimensions}
-                position={pos}
-                selected={!!this.state.selected[draggable.uuid]}
-                ele={draggable.ele}
-                onDragStart={this.handleDragStart}
-                onDragStop={this.handleDragStop}
-              />
-            );
-          })}
-          {this.props.children}
-          {this.renderSelectionBox()}
+      <div
+        id="canvas-container"
+        className={styles.canvas_container}
+        onMouseDown={this.handleMouseDown}
+        onMouseMove={this.onMouseThrottled}
+        onMouseUp={this.handleMouseUpCapture}
+        onDoubleClick={this.handleDoubleClick}
+      >
+        <div className={styles.canvas_background}>
+          <div
+            data-testid="canvas"
+            style={{ height: this.state.height }}
+            id="canvas"
+            ref={(ele: HTMLDivElement) => {
+              this.ele = ele;
+            }}
+            className={styles.canvas}
+          >
+            {this.props.newDragElement}
+            {this.props.draggables.map((draggable: CanvasDraggableProps, idx: number) => {
+              const pos = this.state.positions[draggable.uuid] || draggable.position;
+              return (
+                <CanvasDraggable
+                  onAnimated={this.handleAnimated}
+                  key={'draggable_' + draggable.uuid}
+                  uuid={draggable.uuid}
+                  updateDimensions={this.handleUpdateDimensions}
+                  position={pos}
+                  idx={draggable.idx}
+                  selected={!!this.state.selected[draggable.uuid]}
+                  elementCreator={draggable.elementCreator}
+                  onDragStart={this.handleDragStart}
+                  onDragStop={this.handleDragStop}
+                  dragOnAdd={draggable.dragOnAdd}
+                  config={draggable.config}
+                />
+              );
+            })}
+            {this.renderSelectionBox()}
+          </div>
         </div>
       </div>
     );

--- a/src/components/canvas/CanvasDraggable.tsx
+++ b/src/components/canvas/CanvasDraggable.tsx
@@ -4,11 +4,16 @@ import * as React from 'react';
 import { newPosition } from 'store/helpers';
 
 import styles from './CanvasDraggable.module.scss';
+import { onNextRender } from 'utils';
 
 export interface CanvasDraggableProps {
   position: FlowPosition;
   uuid: string;
-  ele: (selected: boolean) => JSX.Element;
+  idx: number;
+  elementCreator: (props: CanvasDraggableProps) => JSX.Element;
+  config?: any;
+  // should our draggable be initialized as dragged
+  dragOnAdd?: boolean;
 
   selected?: boolean;
 
@@ -18,7 +23,12 @@ export interface CanvasDraggableProps {
   onDragStop?: () => void;
 }
 
-export class CanvasDraggable extends React.PureComponent<CanvasDraggableProps, {}> {
+export interface CanvasDraggableState {
+  width?: number;
+  height?: number;
+}
+
+export class CanvasDraggable extends React.Component<CanvasDraggableProps, CanvasDraggableState> {
   private ele!: HTMLDivElement;
 
   constructor(props: CanvasDraggableProps) {
@@ -26,6 +36,8 @@ export class CanvasDraggable extends React.PureComponent<CanvasDraggableProps, {
     bindCallbacks(this, {
       include: [/^handle/, 'ref']
     });
+
+    this.state = {};
   }
 
   private ref(ref: HTMLDivElement): any {
@@ -35,24 +47,83 @@ export class CanvasDraggable extends React.PureComponent<CanvasDraggableProps, {
   public componentDidMount(): void {
     if (this.ele) {
       if (this.props.updateDimensions) {
-        this.props.updateDimensions(this.props.uuid, {
-          width: this.ele.clientWidth || this.props.position.right - this.props.position.left,
-          height: this.ele.clientHeight || this.props.position.bottom - this.props.position.top
+        const width = this.ele.clientWidth || this.props.position.right - this.props.position.left;
+        const height =
+          this.ele.clientHeight || this.props.position.bottom - this.props.position.top;
+        this.setState({ width, height }, () => {
+          this.props.updateDimensions(this.props.uuid, {
+            width,
+            height
+          });
         });
       }
     }
   }
 
-  public componentDidUpdate(prevProps: CanvasDraggableProps): void {
-    if (this.ele) {
-      if (this.ele.clientWidth && this.ele.clientHeight) {
-        if (this.props.updateDimensions) {
-          this.props.updateDimensions(this.props.uuid, {
-            width: this.ele.clientWidth,
-            height: this.ele.clientHeight
-          });
+  public shouldComponentUpdate(nextProps: CanvasDraggableProps, state: any, context: any): boolean {
+    return (
+      nextProps.position.left !== this.props.position.left ||
+      nextProps.position.top !== this.props.position.top ||
+      nextProps.position.right !== this.props.position.right ||
+      nextProps.position.bottom !== this.props.position.bottom ||
+      nextProps.idx !== this.props.idx ||
+      nextProps.selected !== this.props.selected ||
+      nextProps.config !== this.props.config
+    );
+  }
+
+  public componentDidUpdate(
+    prevProps: CanvasDraggableProps,
+    prevState: CanvasDraggableState
+  ): void {
+    // traceUpdate(this, prevProps, prevState);
+
+    // we want to check our dimensions after our next render
+    onNextRender(() => {
+      if (this.ele) {
+        if (this.ele.clientWidth && this.ele.clientHeight) {
+          if (
+            this.state.width !== this.ele.clientWidth ||
+            this.state.height !== this.ele.clientHeight
+          ) {
+            if (this.props.updateDimensions) {
+              const height = this.ele.clientHeight;
+              const width = this.ele.clientWidth;
+
+              this.setState({ width, height }, () => {
+                this.props.updateDimensions(this.props.uuid, { width, height });
+              });
+            }
+          }
         }
       }
+    });
+  }
+
+  private handleMouseUp(event: React.MouseEvent<HTMLDivElement>): void {
+    if (event.nativeEvent.which === 3) {
+      return;
+    }
+    if (this.props.onDragStop) {
+      this.props.onDragStop();
+    }
+  }
+
+  private handleMouseDown(event: React.MouseEvent<HTMLDivElement>) {
+    // ignore clicks in textareas
+    if (!this.props.selected && (event.target as any).tagName.toUpperCase() === 'TEXTAREA') {
+      return;
+    }
+
+    // ignore right clicks
+    if (event.nativeEvent.which === 3) {
+      return;
+    }
+    if (this.props.onDragStart) {
+      this.props.onDragStart(
+        this.props.uuid,
+        newPosition(event.pageX - this.props.position.left, event.pageY - this.props.position.top)
+      );
     }
   }
 
@@ -79,36 +150,10 @@ export class CanvasDraggable extends React.PureComponent<CanvasDraggableProps, {
           left: this.props.position.left,
           top: this.props.position.top
         }}
-        onMouseDown={(event: React.MouseEvent<HTMLDivElement>) => {
-          // ignore clicks in textareas
-          if (!this.props.selected && (event.target as any).tagName.toUpperCase() === 'TEXTAREA') {
-            return;
-          }
-
-          // ignore right clicks
-          if (event.nativeEvent.which === 3) {
-            return;
-          }
-          if (this.props.onDragStart) {
-            this.props.onDragStart(
-              this.props.uuid,
-              newPosition(
-                event.pageX - this.props.position.left,
-                event.pageY - this.props.position.top
-              )
-            );
-          }
-        }}
-        onMouseUp={(event: React.MouseEvent<HTMLDivElement>) => {
-          if (event.nativeEvent.which === 3) {
-            return;
-          }
-          if (this.props.onDragStop) {
-            this.props.onDragStop();
-          }
-        }}
+        onMouseDown={this.handleMouseDown}
+        onMouseUp={this.handleMouseUp}
       >
-        {this.props.ele(this.props.selected!)}
+        {this.props.elementCreator(this.props)}
       </div>
     );
   }

--- a/src/components/canvas/__snapshots__/Canvas.test.tsx.snap
+++ b/src/components/canvas/__snapshots__/Canvas.test.tsx.snap
@@ -5,21 +5,23 @@ exports[`Canvas adjusts the height when updating dimensions 1`] = `
   <div>
     <div
       class="canvas_container"
+      id="canvas-container"
     >
       <div
-        class="canvas"
-        data-testid="canvas"
-        id="477ac8b4-25e2-483a-8686-2d1332c4da1c"
-        style="height: 1700px;"
+        class="canvas_background"
       >
         <div
-          class="draggable"
-          data-testid="draggable_132de855-4042-4dc1-a18f-cc2e6a8f790a"
-          style="left: 100px; top: 1200px;"
+          class="canvas"
+          data-testid="canvas"
+          id="canvas"
+          style="height: 1700px;"
         >
-          <div>
-            I am a draggable element
-          </div>
+          <div />
+          <div
+            class="draggable"
+            data-testid="draggable_132de855-4042-4dc1-a18f-cc2e6a8f790a"
+            style="left: 100px; top: 1200px;"
+          />
         </div>
       </div>
     </div>
@@ -32,21 +34,23 @@ exports[`Canvas initializes the height to the lowest draggable 1`] = `
   <div>
     <div
       class="canvas_container"
+      id="canvas-container"
     >
       <div
-        class="canvas"
-        data-testid="canvas"
-        id="477ac8b4-25e2-483a-8686-2d1332c4da1c"
-        style="height: 1590px;"
+        class="canvas_background"
       >
         <div
-          class="draggable"
-          data-testid="draggable_1e47a1e1-3c67-4df5-adf1-da542c789adb"
-          style="left: 100px; top: 1200px;"
+          class="canvas"
+          data-testid="canvas"
+          id="canvas"
+          style="height: 1590px;"
         >
-          <div>
-            I am a draggable element
-          </div>
+          <div />
+          <div
+            class="draggable"
+            data-testid="draggable_1e47a1e1-3c67-4df5-adf1-da542c789adb"
+            style="left: 100px; top: 1200px;"
+          />
         </div>
       </div>
     </div>
@@ -67,13 +71,20 @@ exports[`Canvas render default 1`] = `
   <div>
     <div
       class="canvas_container"
+      id="canvas-container"
     >
       <div
-        class="canvas"
-        data-testid="canvas"
-        id="477ac8b4-25e2-483a-8686-2d1332c4da1c"
-        style="height: 0px;"
-      />
+        class="canvas_background"
+      >
+        <div
+          class="canvas"
+          data-testid="canvas"
+          id="canvas"
+          style="height: 0px;"
+        >
+          <div />
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/src/components/flow/Flow.module.scss
+++ b/src/components/flow/Flow.module.scss
@@ -1,11 +1,11 @@
-@import "variables.module.scss";
+@import 'variables.module.scss';
 
 .empty_flow {
-  margin: 13px;
+  margin: 30px;
   width: 400px;
 
   h1 {
-    font-family: "Helvetica Neue", "RobotoThin", sans-serif;
+    font-family: 'Helvetica Neue', 'RobotoThin', sans-serif;
     letter-spacing: 1px;
     padding: 0;
     text-transform: none;

--- a/src/components/flow/Flow.test.ts
+++ b/src/components/flow/Flow.test.ts
@@ -32,9 +32,11 @@ const {
 const { renderNodeMap: initialNodes } = getFlowComponents(definition);
 
 const baseProps: FlowStoreProps = {
-  editorState: {
-    ghostNode: null
-  },
+  ghostNode: null,
+  debug: null,
+  translating: false,
+  popped: null,
+  dragActive: false,
   mergeEditorState: jest.fn(),
   definition,
   nodeEditorSettings: null,
@@ -148,16 +150,6 @@ describe(Flow.name, () => {
 
       expect(wrapper.find('Connect(Simulator)').props()).toMatchSnapshot();
     });
-
-    it('should render dragNode', () => {
-      const { wrapper, instance, props } = setup(true, {
-        mergeEditorState: set(jest.fn()),
-        editorState: { ghostNode: set(ghostNodeFromWait) }
-      });
-      const ghost = getSpecWrapper(wrapper, ghostNodeSpecId);
-      expect(ghost.key()).toBe(props.editorState.ghostNode.node.uuid);
-      expect(ghost).toMatchSnapshot();
-    });
   });
 
   describe('instance methods', () => {
@@ -245,17 +237,14 @@ describe(Flow.name, () => {
 
         expect(instance.Plumber.recalculate).not.toHaveBeenCalled();
         expect(instance.Plumber.connect).not.toHaveBeenCalled();
-        expect(props.mergeEditorState).toHaveBeenCalled();
         expect(props.onOpenNodeEditor).not.toHaveBeenCalled();
       });
 
       it('should do NodeEditor work if the user is not dragging back', () => {
         // tslint:disable-next-line:no-shadowed-variable
         const { instance, props } = setup(true, {
-          editorState: {
-            onOpenNodeEditor: setMock(),
-            ghostNode: set(ghostNodeFromWait)
-          }
+          onOpenNodeEditor: setMock(),
+          ghostNode: set(ghostNodeFromWait)
         });
 
         instance.onConnectorDrop({
@@ -266,9 +255,7 @@ describe(Flow.name, () => {
         jest.runAllTimers();
 
         expect(instance.Plumber.recalculate).toHaveBeenCalledTimes(1);
-        expect(instance.Plumber.recalculate).toHaveBeenCalledWith(
-          props.editorState.ghostNode.node.uuid
-        );
+        expect(instance.Plumber.recalculate).toHaveBeenCalledWith(props.ghostNode.node.uuid);
         expect(instance.Plumber.connect).toHaveBeenCalledTimes(1);
         expect(instance.Plumber.connect).toMatchCallSnapshot();
 
@@ -281,9 +268,7 @@ describe(Flow.name, () => {
       it('should return reversse of translating prop', () => {
         const { wrapper, instance, props } = setup();
 
-        expect(instance.beforeConnectionDrag(mockConnectionEvent)).toBe(
-          !props.editorState.translating
-        );
+        expect(instance.beforeConnectionDrag(mockConnectionEvent)).toBe(!props.translating);
       });
     });
   });

--- a/src/components/flow/__snapshots__/Flow.test.ts.snap
+++ b/src/components/flow/__snapshots__/Flow.test.ts.snap
@@ -12,7 +12,7 @@ Object {
 exports[`Flow instance methods onConnectorDrop should do NodeEditor work if the user is not dragging back 1`] = `
 Array [
   "46e8d603-8e5d-4435-97dd-1333291aafca:8653ac06-00ba-4890-a79f-d30f3a55193b",
-  "dbb8e943-0501-4405-aeaa-627414f976e1",
+  "52036e99-4be0-4505-add4-159e8d1d7572",
   [Function],
 ]
 `;
@@ -23,7 +23,7 @@ Array [
     "originalAction": Object {
       "text": "",
       "type": "send_msg",
-      "uuid": "4993f221-2381-47f9-97c3-878dc5ef258c",
+      "uuid": "7966434b-6d38-4d8b-b01c-13d3d9aa593c",
     },
     "originalNode": Object {
       "ghost": true,
@@ -35,16 +35,16 @@ Array [
           Object {
             "text": "",
             "type": "send_msg",
-            "uuid": "4993f221-2381-47f9-97c3-878dc5ef258c",
+            "uuid": "7966434b-6d38-4d8b-b01c-13d3d9aa593c",
           },
         ],
         "exits": Array [
           Object {
             "destination_uuid": null,
-            "uuid": "712ff538-daa1-4ab2-8ce3-762bc0bf7f12",
+            "uuid": "431dadb3-0257-432f-ace3-52157bba69ed",
           },
         ],
-        "uuid": "dbb8e943-0501-4405-aeaa-627414f976e1",
+        "uuid": "52036e99-4be0-4505-add4-159e8d1d7572",
       },
       "ui": Object {
         "position": Object {
@@ -67,52 +67,8 @@ Object {
 
 exports[`Flow render should render Simulator 1`] = `
 Object {
-  "mergeEditorState": [MockFunction] {
-    "calls": Array [
-      Array [
-        Object {
-          "containerOffset": Object {
-            "left": 0,
-            "top": 0,
-          },
-        },
-      ],
-    ],
-    "results": Array [
-      Object {
-        "type": "return",
-        "value": undefined,
-      },
-    ],
-  },
+  "mergeEditorState": [MockFunction],
   "onToggled": [Function],
-  "popped": undefined,
+  "popped": null,
 }
-`;
-
-exports[`Flow render should render dragNode 1`] = `
-<div
-  data-spec="ghost-node"
-  key="09294c2a-031e-4e74-9b1c-aec239b2a145"
-  style={
-    Object {
-      "display": "block",
-      "position": "absolute",
-      "visibility": "hidden",
-    }
-  }
->
-  <Connect(NodeComp)
-    ghost={true}
-    nodeUUID="09294c2a-031e-4e74-9b1c-aec239b2a145"
-    onlyNode={false}
-    plumberConnectExit={[MockFunction]}
-    plumberMakeSource={[MockFunction]}
-    plumberMakeTarget={[MockFunction]}
-    plumberRecalculate={[MockFunction]}
-    plumberRemove={[MockFunction]}
-    selected={false}
-    startingNode={false}
-  />
-</div>
 `;

--- a/src/components/flow/node/Node.test.tsx
+++ b/src/components/flow/node/Node.test.tsx
@@ -20,7 +20,6 @@ const baseProps: NodeProps = {
 
   results: {},
   activeCount: 0,
-  containerOffset: { top: 0, left: 0 },
   translating: false,
   simulating: false,
   debug: null,

--- a/src/components/flow/node/Node.tsx
+++ b/src/components/flow/node/Node.tsx
@@ -69,7 +69,6 @@ export interface NodeStoreProps {
   language: Asset;
   languages: AssetMap;
   activeCount: number;
-  containerOffset: { top: number; left: number };
   translating: boolean;
   simulating: boolean;
   debug: DebugState;
@@ -123,10 +122,12 @@ export class NodeComp extends React.PureComponent<NodeProps> {
 
   private getGhostListener(): any {
     return (e: MouseEvent) => {
+      const canvasBounds = this.ele.parentElement.parentElement.getBoundingClientRect();
+
       // move our ghost node into position
       const width = this.ele.getBoundingClientRect().width;
-      const left = e.pageX - width / 2 - 15;
-      const top = e.pageY + this.ele.scrollTop - (this.props.containerOffset.top + 20);
+      const left = e.pageX - width / 2 - 15 - canvasBounds.left;
+      const top = e.pageY - canvasBounds.top - window.scrollY;
       const style = this.ele.style;
       style.left = left + 'px';
       style.top = top + 'px';
@@ -458,7 +459,6 @@ const mapStateToProps = (
       debug,
       ghostNode,
       simulating,
-      containerOffset,
       activity,
       language,
       scrollToAction,
@@ -495,7 +495,6 @@ const mapStateToProps = (
     language,
     languages,
     activeCount,
-    containerOffset,
     translating,
     debug,
     renderNode,

--- a/src/components/index.module.scss
+++ b/src/components/index.module.scss
@@ -5,8 +5,8 @@
   font-family: 'Roboto', sans-serif;
   font-weight: 300;
   color: $text_color; // height: 100vh;
-  height: 100%;
-  width: 100%;
+  // height: 100%;
+  // width: 100%;
   font-size: 13px;
   line-height: 1.2;
   margin: 0;

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -263,6 +263,7 @@ export class FlowEditor extends React.Component<FlowEditorStoreProps> {
               />
             )}
             <div id="portal-root" />
+            <div id="canvas-portal" />
           </div>
         </div>
       </PageVisibility>

--- a/src/components/languageselector/LanguageSelector.module.scss
+++ b/src/components/languageselector/LanguageSelector.module.scss
@@ -1,11 +1,11 @@
-@import "variables.module.scss";
+@import 'variables.module.scss';
 
 :global {
   .language-selector {
     z-index: $z_editor_menu;
     position: absolute;
     right: 30px;
-    top: 0px;
+    top: 23px;
     user-select: none;
   }
 }

--- a/src/global.module.scss
+++ b/src/global.module.scss
@@ -7,11 +7,6 @@
 }
 
 :global {
-  ::-webkit-scrollbar {
-    width: 0px !important;
-    background: transparent !important;
-  }
-
   body {
     margin: 0;
     font-family: 'Roboto', sans-serif;

--- a/src/store/__snapshots__/thunks.test.ts.snap
+++ b/src/store/__snapshots__/thunks.test.ts.snap
@@ -373,10 +373,6 @@ Array [
           "root": Array [],
           "types": Array [],
         },
-        "containerOffset": Object {
-          "left": 0,
-          "top": 0,
-        },
         "currentRevision": null,
         "debug": null,
         "dragActive": false,
@@ -420,10 +416,6 @@ Array [
         "completionSchema": Object {
           "root": Array [],
           "types": Array [],
-        },
-        "containerOffset": Object {
-          "left": 0,
-          "top": 0,
         },
         "currentRevision": null,
         "debug": null,
@@ -1154,10 +1146,6 @@ Array [
         "completionSchema": Object {
           "root": Array [],
           "types": Array [],
-        },
-        "containerOffset": Object {
-          "left": 0,
-          "top": 0,
         },
         "currentRevision": null,
         "debug": null,

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -46,7 +46,6 @@ export interface EditorState {
   translating: boolean;
   fetchingFlow: boolean;
   ghostNode: RenderNode | null;
-  containerOffset: { left: number; top: number };
   dragActive: boolean;
   dragStartTime: number;
   dragDownPosition: FlowPosition | null;
@@ -104,7 +103,6 @@ export const EMPTY_DRAG_STATE: any = {
 export const initialState: EditorState = {
   completionSchema: { types: [], root: [] },
   functions: [],
-  containerOffset: { top: 0, left: 0 },
   currentRevision: null,
   simulating: false,
   translating: false,

--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -680,10 +680,6 @@ export const fetchFlowActivity = (
   getState: GetState,
   uuid: string
 ): void => {
-  if (true) {
-    return;
-  }
-
   const {
     editorState: { simulating, activityInterval, visible }
   } = getState();

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -453,3 +453,14 @@ export const traceUpdate = (component: any, prevProps: any, prevState?: any) => 
     });
   }
 };
+
+export const debounce = (fn: any, quiet: number, closure: any = null) => {
+  if (fn.timeout) {
+    window.clearTimeout(fn.timeout);
+  }
+  fn.timeout = window.setTimeout(closure || fn, quiet);
+};
+
+export const onNextRender = (fn: any) => {
+  window.setTimeout(fn, 0);
+};


### PR DESCRIPTION
Significantly reworks canvas structure in order to support horizontal scrolling. Pushes drag node down to canvas so it can work with native offsets (removing a 2x render cost on load).  Traced and removed more unnecessary (hopefully!) updates for better performance on large flows. Debounce re-anchoring connections on drag so it is smoother on large flows.