### PR TITLE
Field route fix

### DIFF
--- a/src/components/flow/routers/field/FieldRouterForm.test.ts
+++ b/src/components/flow/routers/field/FieldRouterForm.test.ts
@@ -2,9 +2,11 @@ import { RouterFormProps } from 'components/flow/props';
 import { CaseProps } from 'components/flow/routers/caselist/CaseList';
 import { Operators, Types } from 'config/interfaces';
 import { AssetType } from 'store/flowContext';
+import { getUpdatedNode } from 'test/utils';
 import { composeComponentTestUtils, mock } from 'testUtils';
 import { createMatchRouter, getRouterFormProps } from 'testUtils/assetCreators';
 import * as utils from 'utils';
+import { getSwitchRouter } from '../helpers';
 
 import FieldRouterForm from './FieldRouterForm';
 
@@ -82,14 +84,37 @@ describe(FieldRouterForm.name, () => {
         $merge: { updateRouter: jest.fn(), onClose: jest.fn() }
       });
 
-      instance.handleFieldChanged({
-        id: 'viber',
-        name: 'Viber',
-        type: AssetType.URN
-      });
+      instance.handleFieldChanged([
+        {
+          id: 'viber',
+          name: 'Viber',
+          type: AssetType.URN
+        }
+      ]);
       instance.getButtons().secondary.onClick();
       expect(props.onClose).toHaveBeenCalled();
       expect(props.updateRouter).not.toHaveBeenCalled();
+    });
+
+    it('should build expression from a selected field', () => {
+      const { instance, props } = setup(true, {
+        $merge: { updateRouter: jest.fn(), onClose: jest.fn() }
+      });
+
+      instance.handleFieldChanged([
+        {
+          key: 'my_field',
+          label: 'My Field'
+        }
+      ]);
+
+      instance.handleSave();
+
+      const node = getUpdatedNode(instance.props);
+      expect(getSwitchRouter(node.node).operand).toEqual('@fields.my_field');
+
+      expect(props.updateRouter).toHaveBeenCalled();
+      expect(props.updateRouter).toMatchCallSnapshot();
     });
   });
 });

--- a/src/components/flow/routers/field/FieldRouterForm.tsx
+++ b/src/components/flow/routers/field/FieldRouterForm.tsx
@@ -9,7 +9,6 @@ import AssetSelector from 'components/form/assetselector/AssetSelector';
 import TypeList from 'components/nodeeditor/TypeList';
 import { fakePropType } from 'config/ConfigProvider';
 import * as React from 'react';
-import { Asset } from 'store/flowContext';
 import { FormEntry, FormState, StringEntry } from 'store/nodeEditor';
 import { Alphanumeric, StartIsNonNumeric, validate } from 'store/validators';
 
@@ -64,7 +63,7 @@ export default class FieldRouterForm extends React.Component<
     });
   }
 
-  private handleFieldChanged(selected: Asset[]): void {
+  private handleFieldChanged(selected: any[]): void {
     this.setState({ field: { value: selected[0] } });
   }
 

--- a/src/components/flow/routers/field/FieldRouterForm.tsx
+++ b/src/components/flow/routers/field/FieldRouterForm.tsx
@@ -10,7 +10,7 @@ import TypeList from 'components/nodeeditor/TypeList';
 import { fakePropType } from 'config/ConfigProvider';
 import * as React from 'react';
 import { Asset } from 'store/flowContext';
-import { AssetEntry, FormState, StringEntry } from 'store/nodeEditor';
+import { FormEntry, FormState, StringEntry } from 'store/nodeEditor';
 import { Alphanumeric, StartIsNonNumeric, validate } from 'store/validators';
 
 import styles from './FieldRouterForm.module.scss';
@@ -28,7 +28,7 @@ export enum InputToFocus {
 }
 
 export interface FieldRouterFormState extends FormState {
-  field: AssetEntry;
+  field: FormEntry;
   cases: CaseProps[];
   resultName: StringEntry;
 }

--- a/src/components/flow/routers/field/__snapshots__/FieldRouterForm.test.ts.snap
+++ b/src/components/flow/routers/field/__snapshots__/FieldRouterForm.test.ts.snap
@@ -416,6 +416,66 @@ exports[`FieldRouterForm should render 1`] = `
 </Dialog>
 `;
 
+exports[`FieldRouterForm updates should build expression from a selected field 1`] = `
+Array [
+  Object {
+    "inboundConnections": Object {},
+    "node": Object {
+      "actions": Array [],
+      "exits": Array [
+        Object {
+          "uuid": "1dce2b34-9aab-4e20-81c4-3f0408dcb671",
+        },
+        Object {
+          "uuid": "477ac8b4-25e2-483a-8686-2d1332c4da1c",
+        },
+      ],
+      "router": Object {
+        "cases": Array [
+          Object {
+            "arguments": Array [
+              "red",
+            ],
+            "category_uuid": "763e4844-3e1b-407a-a1b5-5fdfcd308b41",
+            "type": "has_any_word",
+            "uuid": "061fc171-8b79-4636-b892-bd0ea5aa9b42",
+          },
+        ],
+        "categories": Array [
+          Object {
+            "exit_uuid": "1dce2b34-9aab-4e20-81c4-3f0408dcb671",
+            "name": "Red",
+            "uuid": "763e4844-3e1b-407a-a1b5-5fdfcd308b41",
+          },
+          Object {
+            "exit_uuid": "477ac8b4-25e2-483a-8686-2d1332c4da1c",
+            "name": "Other",
+            "uuid": "1e47a1e1-3c67-4df5-adf1-da542c789adb",
+          },
+        ],
+        "default_category_uuid": "1e47a1e1-3c67-4df5-adf1-da542c789adb",
+        "operand": "@fields.my_field",
+        "result_name": "Color",
+        "type": "switch",
+      },
+      "uuid": "132de855-4042-4dc1-a18f-cc2e6a8f790a",
+    },
+    "ui": Object {
+      "config": Object {
+        "cases": Object {},
+        "operand": Object {
+          "id": "my_field",
+          "name": "My Field",
+          "type": "field",
+        },
+      },
+      "position": null,
+      "type": "split_by_contact_field",
+    },
+  },
+]
+`;
+
 exports[`FieldRouterForm updates should save changes 1`] = `
 Object {
   "cases": Array [

--- a/src/components/flow/routers/field/helpers.ts
+++ b/src/components/flow/routers/field/helpers.ts
@@ -54,11 +54,11 @@ export const nodeToState = (
     if (assetStore.fields) {
       if (operand.id in assetStore.fields.items) {
         const name = assetStore.fields.items[operand.id].name;
-        field = { id: operand.id, type: operand.type, name };
+        field = { key: operand.id, label: name, type: operand.type };
       }
     }
 
-    // couldn't find the asset, checkour routable fields
+    // couldn't find the asset, check our routable fields
     if (!field) {
       field = getRoutableFields().find((asset: Asset) => asset.id === operand.id);
     }
@@ -93,13 +93,26 @@ export const stateToNode = (
   }
 
   let operand = DEFAULT_OPERAND;
+
   const asset = state.field.value;
+
+  let operandConfig = {
+    id: asset.id,
+    type: asset.type,
+    name: asset.name
+  };
+
   if (asset.type === AssetType.Scheme) {
     operand = `@(default(urn_parts(urns.${asset.id}).path, ""))`;
-  } else if (asset.type === AssetType.Field) {
-    operand = `@fields.${asset.id}`;
-  } else {
+  } else if (asset.type === AssetType.ContactProperty) {
     operand = `@contact.${asset.id}`;
+  } else if (asset.key) {
+    operand = `@fields.${asset.key}`;
+    operandConfig = {
+      id: asset.key,
+      name: asset.label,
+      type: AssetType.Field
+    };
   }
 
   const router: SwitchRouter = {
@@ -118,11 +131,7 @@ export const stateToNode = (
     Types.split_by_contact_field,
     [],
     {
-      operand: {
-        id: asset.id,
-        type: asset.type,
-        name: asset.name
-      },
+      operand: operandConfig,
       cases: caseConfig
     }
   );


### PR DESCRIPTION
Fields selected via the asset selector are field objects now, but the expression builder wasn't accounting for that. This also adds a test for expressions created from field operands.