### PR TITLE
CurrencyElement fix

### DIFF
--- a/src/components/flow/routers/airtime/AirtimeRouterForm.tsx
+++ b/src/components/flow/routers/airtime/AirtimeRouterForm.tsx
@@ -30,8 +30,6 @@ export default class AirtimeRouterForm extends React.PureComponent<
   RouterFormProps,
   AirtimeRouterFormState
 > {
-  options: any[] = [];
-
   constructor(props: RouterFormProps) {
     super(props);
 
@@ -39,13 +37,6 @@ export default class AirtimeRouterForm extends React.PureComponent<
 
     bindCallbacks(this, {
       include: [/^on/, /^handle/]
-    });
-  }
-
-  public componentDidMount(): void {
-    const items = this.props.assetStore.currencies ? this.props.assetStore.currencies.items : {};
-    this.options = Object.keys(items).map((key: string) => {
-      return { id: items[key].id };
     });
   }
 
@@ -133,7 +124,7 @@ export default class AirtimeRouterForm extends React.PureComponent<
       <CurrencyElement
         key={'currency_' + index}
         exclude={this.state.amounts}
-        currencies={this.options}
+        currencies={this.props.assetStore.currencies}
         transfer={entry}
         index={index}
         onChange={this.handleTransferChanged}

--- a/src/components/flow/routers/airtime/__snapshots__/AirtimeRouterForm.test.ts.snap
+++ b/src/components/flow/routers/airtime/__snapshots__/AirtimeRouterForm.test.ts.snap
@@ -45,7 +45,6 @@ exports[`AirtimeRouterForm render should render 1`] = `
   />
   <div>
     <CurrencyElement
-      currencies={Array []}
       exclude={
         Array [
           Object {
@@ -70,7 +69,6 @@ exports[`AirtimeRouterForm render should render 1`] = `
       }
     />
     <CurrencyElement
-      currencies={Array []}
       exclude={
         Array [
           Object {

--- a/src/components/flow/routers/airtime/currency/CurrencyElement.module.scss
+++ b/src/components/flow/routers/airtime/currency/CurrencyElement.module.scss
@@ -13,7 +13,7 @@
     .amount {
       flex-grow: 1;
       margin-left: 10px;
-      margin-top: 5px;
+      margin-top: 0px;
       vertical-align: top;
       input {
         font-size: 12px !important;
@@ -25,8 +25,9 @@
 
     .remove {
       display: inline-block;
-      font-size: 10px;
-      padding-left: 5px;
+      font-size: 13px;
+      padding-left: 8px;
+      padding-top: 4px;
       visibility: hidden;
       cursor: pointer;
     }

--- a/src/components/flow/routers/airtime/currency/CurrencyElement.tsx
+++ b/src/components/flow/routers/airtime/currency/CurrencyElement.tsx
@@ -2,9 +2,9 @@ import { react as bindCallbacks } from 'auto-bind';
 import { AirtimeTransferEntry } from 'components/flow/routers/airtime/AirtimeRouterForm';
 import AssetSelector from 'components/form/assetselector/AssetSelector';
 import FormElement from 'components/form/FormElement';
-import TextInputElement from 'components/form/textinput/TextInputElement';
+import TextInputElement, { TextInputStyle } from 'components/form/textinput/TextInputElement';
 import * as React from 'react';
-import { Asset } from 'store/flowContext';
+import { Asset, Assets } from 'store/flowContext';
 import { ValidationFailure } from 'store/nodeEditor';
 
 import styles from './CurrencyElement.module.scss';
@@ -17,7 +17,7 @@ export interface AirtimeTransfer {
 }
 
 export interface CurrencyElementProps {
-  currencies: any[];
+  currencies: Assets;
   transfer: AirtimeTransferEntry;
   index: number;
   exclude: AirtimeTransferEntry[];
@@ -78,6 +78,7 @@ export default class CurrencyElement extends React.Component<CurrencyElementProp
             name={i18n.t('forms.value', 'value')}
             onChange={this.handleAmountChanged}
             entry={{ value: amount }}
+            style={TextInputStyle.medium}
           />
         </div>
       ) : null;
@@ -118,7 +119,7 @@ export default class CurrencyElement extends React.Component<CurrencyElementProp
               nameKey="id"
               valueKey="id"
               onChange={this.handleCurrencyChanged}
-              additionalOptions={this.props.currencies}
+              assets={this.props.currencies}
               placeholder={i18n.t('forms.currency', 'Select a Currency')}
             />
           </div>

--- a/src/components/form/assetselector/AssetSelector.tsx
+++ b/src/components/form/assetselector/AssetSelector.tsx
@@ -91,7 +91,7 @@ export default class AssetSelector extends React.Component<AssetSelectorProps, A
     }
 
     // if we don't have an endpoint, populate our options with items
-    if (!this.props.assets.endpoint) {
+    if (this.props.assets && !this.props.assets.endpoint) {
       this.options = this.options.concat(
         Object.keys(this.props.assets.items).map((id: string) => this.props.assets.items[id])
       );
@@ -227,7 +227,9 @@ export default class AssetSelector extends React.Component<AssetSelectorProps, A
           cacheKey={this.lastCreation + ''}
           options={this.options}
           sortFunction={this.props.sortFunction || sortByName}
-          queryParam={this.props.assets.type === AssetType.Contact ? 'search' : null}
+          queryParam={
+            this.props.assets && this.props.assets.type === AssetType.Contact ? 'search' : null
+          }
         />
       </FormElement>
     );

--- a/src/components/form/textinput/TextInputElement.module.scss
+++ b/src/components/form/textinput/TextInputElement.module.scss
@@ -5,6 +5,11 @@
   --temba-textinput-font-size: 12px !important;
 }
 
+.medium {
+  --temba-textinput-padding: 7px 8px !important;
+  --temba-textinput-font-size: 12px !important;
+}
+
 .normal {
 }
 

--- a/src/components/form/textinput/TextInputElement.tsx
+++ b/src/components/form/textinput/TextInputElement.tsx
@@ -11,6 +11,7 @@ export enum Count {
 
 export enum TextInputStyle {
   small = 'small',
+  medium = 'medium',
   normal = 'normal'
 }
 


### PR DESCRIPTION
This was broken with the `AssetSelector` switch. `AirtimeRouterForm` did not pass down an `Assets` object (instead building the currency objects itself). Now that `CurrencyElement` uses an `AssetSelector` under the hood, it can just send the `Assets` object for currencies.