### PR TITLE
Fix: wrong attribute comparison for templates variables on change

### DIFF
--- a/src/components/flow/actions/sendmsg/SendMsgForm.tsx
+++ b/src/components/flow/actions/sendmsg/SendMsgForm.tsx
@@ -392,7 +392,7 @@ export default class SendMsgForm extends React.Component<ActionFormProps, SendMs
 
       const templateVariables =
         this.state.templateVariables.length === 0 ||
-        (this.state.template.value && this.state.template.value.id !== template.id)
+        (this.state.template.value && this.state.template.value.uuid !== template.uuid)
           ? range(0, templateTranslation.variable_count).map(() => {
               return {
                 value: ''


### PR DESCRIPTION
The attribute `id` does not exist in neither `template` and `this.state.template.value`. 
Both of them have the `uuid` attribute.
The comparison was `undefined !== undefined`, leading to always return the `this.state.templateVariables` for `templateVariables`.

Closes: https://github.com/rapidpro/rapidpro/issues/1432
