### PR TITLE
Only restrict rules on digits router for ivr flows

### DIFF
--- a/src/components/flow/actions/sendmsg/SendMsgForm.tsx
+++ b/src/components/flow/actions/sendmsg/SendMsgForm.tsx
@@ -390,7 +390,7 @@ export default class SendMsgForm extends React.Component<ActionFormProps, SendMs
 
       const templateVariables =
         this.state.templateVariables.length === 0 ||
-        (this.state.template.value && this.state.template.value.id !== template.id)
+        (this.state.template.value && this.state.template.value.uuid !== template.uuid)
           ? range(0, templateTranslation.variable_count).map(() => {
               return {
                 value: ''

--- a/src/components/flow/routers/case/__snapshots__/CaseElement.test.tsx.snap
+++ b/src/components/flow/routers/case/__snapshots__/CaseElement.test.tsx.snap
@@ -328,7 +328,7 @@ exports[`CaseElement render should render empty case 1`] = `
               name="operator"
               namekey="verboseName"
               valuekey="type"
-              values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1,\\"visibility\\":[\\"messaging\\",\\"messaging_background\\",\\"messaging_offline\\"]}]"
+              values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1}]"
             />
           </div>
         </div>
@@ -410,7 +410,7 @@ exports[`CaseElement update handles argument change 1`] = `
               name="operator"
               namekey="verboseName"
               valuekey="type"
-              values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1,\\"visibility\\":[\\"messaging\\",\\"messaging_background\\",\\"messaging_offline\\"]}]"
+              values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1}]"
             />
           </div>
         </div>

--- a/src/components/flow/routers/case/__snapshots__/helpers.test.ts.snap
+++ b/src/components/flow/routers/case/__snapshots__/helpers.test.ts.snap
@@ -143,11 +143,6 @@ Object {
     "operands": 1,
     "type": "has_any_word",
     "verboseName": "has any of the words",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   "state": Object {
     "validationFailures": Array [],
@@ -240,11 +235,6 @@ Object {
     "operands": 1,
     "type": "has_any_word",
     "verboseName": "has any of the words",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   "state": Object {
     "validationFailures": Array [],
@@ -334,11 +324,6 @@ Object {
     "operands": 0,
     "type": "has_text",
     "verboseName": "has some text",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   "state": Object {
     "validationFailures": Array [],

--- a/src/components/flow/routers/caselist/CaseList.tsx
+++ b/src/components/flow/routers/caselist/CaseList.tsx
@@ -11,6 +11,7 @@ import { SortableElement, SortEnd, SortableContainer } from 'react-sortable-hoc'
 import styles from './CaseList.module.scss';
 import { Operator } from 'config/interfaces';
 import { Asset } from 'store/flowContext';
+import { operatorConfigList } from 'config';
 
 export enum DragCursor {
   move = 'move',
@@ -31,7 +32,6 @@ export interface CaseListProps {
   onCasesUpdated(cases: CaseProps[]): void;
   operators?: Operator[];
   classifier?: Asset;
-  createEmptyCase?: () => CaseProps;
 }
 
 export interface CaseListState extends FormState {
@@ -99,7 +99,8 @@ export default class CaseList extends React.Component<CaseListProps, CaseListSta
   }
 
   private createEmptyCase(): CaseProps {
-    return this.props.createEmptyCase ? this.props.createEmptyCase() : createEmptyCase();
+    const operators = this.props.operators || operatorConfigList;
+    return createEmptyCase(operators[0]);
   }
 
   public static contextTypes = {

--- a/src/components/flow/routers/caselist/__snapshots__/CaseList.test.tsx.snap
+++ b/src/components/flow/routers/caselist/__snapshots__/CaseList.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`CaseList render should render empty list 1`] = `
                     name="operator"
                     namekey="verboseName"
                     valuekey="type"
-                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1,\\"visibility\\":[\\"messaging\\",\\"messaging_background\\",\\"messaging_offline\\"]}]"
+                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1}]"
                   />
                 </div>
               </div>
@@ -132,7 +132,7 @@ exports[`CaseList render should render list of cases 1`] = `
                     name="operator"
                     namekey="verboseName"
                     valuekey="type"
-                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1,\\"visibility\\":[\\"messaging\\",\\"messaging_background\\",\\"messaging_offline\\"]}]"
+                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1}]"
                   />
                 </div>
               </div>
@@ -211,7 +211,7 @@ exports[`CaseList render should render list of cases 1`] = `
                     name="operator"
                     namekey="verboseName"
                     valuekey="type"
-                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1,\\"visibility\\":[\\"messaging\\",\\"messaging_background\\",\\"messaging_offline\\"]}]"
+                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1}]"
                   />
                 </div>
               </div>
@@ -290,7 +290,7 @@ exports[`CaseList render should render list of cases 1`] = `
                     name="operator"
                     namekey="verboseName"
                     valuekey="type"
-                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1,\\"visibility\\":[\\"messaging\\",\\"messaging_background\\",\\"messaging_offline\\"]}]"
+                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1}]"
                   />
                 </div>
               </div>
@@ -385,7 +385,7 @@ exports[`CaseList updates should remove cases 1`] = `
                     name="operator"
                     namekey="verboseName"
                     valuekey="type"
-                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1,\\"visibility\\":[\\"messaging\\",\\"messaging_background\\",\\"messaging_offline\\"]}]"
+                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1}]"
                   />
                 </div>
               </div>
@@ -464,7 +464,7 @@ exports[`CaseList updates should remove cases 1`] = `
                     name="operator"
                     namekey="verboseName"
                     valuekey="type"
-                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1,\\"visibility\\":[\\"messaging\\",\\"messaging_background\\",\\"messaging_offline\\"]}]"
+                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1}]"
                   />
                 </div>
               </div>
@@ -559,7 +559,7 @@ exports[`CaseList updates should update cases 1`] = `
                     name="operator"
                     namekey="verboseName"
                     valuekey="type"
-                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1,\\"visibility\\":[\\"messaging\\",\\"messaging_background\\",\\"messaging_offline\\"]}]"
+                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1}]"
                   />
                 </div>
               </div>
@@ -638,7 +638,7 @@ exports[`CaseList updates should update cases 1`] = `
                     name="operator"
                     namekey="verboseName"
                     valuekey="type"
-                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1,\\"visibility\\":[\\"messaging\\",\\"messaging_background\\",\\"messaging_offline\\"]}]"
+                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1}]"
                   />
                 </div>
               </div>
@@ -717,7 +717,7 @@ exports[`CaseList updates should update cases 1`] = `
                     name="operator"
                     namekey="verboseName"
                     valuekey="type"
-                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1,\\"visibility\\":[\\"messaging\\",\\"messaging_background\\",\\"messaging_offline\\"]}]"
+                    values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1}]"
                   />
                 </div>
               </div>

--- a/src/components/flow/routers/caselist/helpers.ts
+++ b/src/components/flow/routers/caselist/helpers.ts
@@ -1,5 +1,5 @@
 import { CaseProps } from 'components/flow/routers/caselist/CaseList';
-import { Operator, Operators } from 'config/interfaces';
+import { Operator } from 'config/interfaces';
 import { createUUID } from 'utils';
 
 export const createEmptyCase = (operator: Operator): CaseProps => {

--- a/src/components/flow/routers/caselist/helpers.ts
+++ b/src/components/flow/routers/caselist/helpers.ts
@@ -1,14 +1,14 @@
 import { CaseProps } from 'components/flow/routers/caselist/CaseList';
-import { Operators } from 'config/interfaces';
+import { Operator, Operators } from 'config/interfaces';
 import { createUUID } from 'utils';
 
-export const createEmptyCase = (): CaseProps => {
+export const createEmptyCase = (operator: Operator): CaseProps => {
   const uuid = createUUID();
   return {
     uuid,
     kase: {
       uuid,
-      type: Operators.has_any_word,
+      type: operator.type,
       arguments: [''],
       category_uuid: null
     },

--- a/src/components/flow/routers/classify/ClassifyRouterForm.tsx
+++ b/src/components/flow/routers/classify/ClassifyRouterForm.tsx
@@ -2,7 +2,7 @@ import { react as bindCallbacks } from 'auto-bind';
 import Dialog, { ButtonSet, Tab } from 'components/dialog/Dialog';
 import { hasErrors, renderIssues } from 'components/flow/actions/helpers';
 import { RouterFormProps } from 'components/flow/props';
-import { nodeToState, stateToNode, createEmptyCase } from './helpers';
+import { nodeToState, stateToNode } from './helpers';
 import { createResultNameInput } from 'components/flow/routers/widgets';
 import TypeList from 'components/nodeeditor/TypeList';
 import * as React from 'react';
@@ -214,7 +214,6 @@ export default class ClassifyRouterForm extends React.Component<
             cases={this.state.cases}
             onCasesUpdated={this.handleCasesUpdated}
             operators={intentOperatorList}
-            createEmptyCase={createEmptyCase}
             classifier={this.state.classifier.value}
           />
         )}

--- a/src/components/flow/routers/classify/helpers.ts
+++ b/src/components/flow/routers/classify/helpers.ts
@@ -174,18 +174,3 @@ export const stateToNode = (
     [newAction]
   );
 };
-
-export const createEmptyCase = (): CaseProps => {
-  const uuid = createUUID();
-  return {
-    uuid,
-    kase: {
-      uuid,
-      type: Operators.has_top_intent,
-      arguments: ['', ''],
-      category_uuid: null
-    },
-    categoryName: '',
-    valid: true
-  };
-};

--- a/src/components/flow/routers/digits/DigitsRouterForm.tsx
+++ b/src/components/flow/routers/digits/DigitsRouterForm.tsx
@@ -12,6 +12,8 @@ import { Alphanumeric, StartIsNonNumeric, validate } from 'store/validators';
 import styles from './DigitsRouterForm.module.scss';
 import { nodeToState, stateToNode } from './helpers';
 import i18n from 'config/i18n';
+import { Operator, Operators } from 'config/interfaces';
+import { operatorConfigList } from 'config/operatorConfigs';
 
 export interface DigitsRouterFormState extends FormState {
   cases: CaseProps[];
@@ -30,6 +32,13 @@ export default class DigitsRouterForm extends React.Component<
     bindCallbacks(this, {
       include: [/^on/, /^handle/]
     });
+  }
+
+  private getOperators(): Operator[] {
+    return operatorConfigList.filter(
+      operator =>
+        operator.type === Operators.has_beginning || operator.type.indexOf('has_number') === 0
+    );
   }
 
   private handleUpdateResultName(value: string): void {
@@ -66,7 +75,7 @@ export default class DigitsRouterForm extends React.Component<
 
   public renderEdit(): JSX.Element {
     const typeConfig = this.props.typeConfig;
-
+    const operators = this.getOperators();
     return (
       <Dialog title={typeConfig.name} headerClass={typeConfig.type} buttons={this.getButtons()}>
         <TypeList __className="" initialType={typeConfig} onChange={this.props.onTypeChange} />
@@ -75,6 +84,7 @@ export default class DigitsRouterForm extends React.Component<
           data-spec="cases"
           cases={this.state.cases}
           onCasesUpdated={this.handleCasesUpdated}
+          operators={operators}
         />
         {createResultNameInput(this.state.resultName, this.handleUpdateResultName)}
         {renderIssues(this.props)}

--- a/src/components/flow/routers/digits/__snapshots__/DigitsRouterForm.test.ts.snap
+++ b/src/components/flow/routers/digits/__snapshots__/DigitsRouterForm.test.ts.snap
@@ -46,6 +46,51 @@ exports[`DigitsRouterForm initializes 1`] = `
     cases={Array []}
     data-spec="cases"
     onCasesUpdated={[Function]}
+    operators={
+      Array [
+        Object {
+          "operands": 1,
+          "type": "has_beginning",
+          "verboseName": "starts with",
+        },
+        Object {
+          "categoryName": "Has Number",
+          "operands": 0,
+          "type": "has_number",
+          "verboseName": "has a number",
+        },
+        Object {
+          "operands": 2,
+          "type": "has_number_between",
+          "verboseName": "has a number between",
+        },
+        Object {
+          "operands": 1,
+          "type": "has_number_lt",
+          "verboseName": "has a number below",
+        },
+        Object {
+          "operands": 1,
+          "type": "has_number_lte",
+          "verboseName": "has a number at or below",
+        },
+        Object {
+          "operands": 1,
+          "type": "has_number_eq",
+          "verboseName": "has a number equal to",
+        },
+        Object {
+          "operands": 1,
+          "type": "has_number_gte",
+          "verboseName": "has a number at or above",
+        },
+        Object {
+          "operands": 1,
+          "type": "has_number_gt",
+          "verboseName": "has a number above",
+        },
+      ]
+    }
   />
   <OptionalTextInput
     helpText={
@@ -119,6 +164,51 @@ exports[`DigitsRouterForm should render 1`] = `
     cases={Array []}
     data-spec="cases"
     onCasesUpdated={[Function]}
+    operators={
+      Array [
+        Object {
+          "operands": 1,
+          "type": "has_beginning",
+          "verboseName": "starts with",
+        },
+        Object {
+          "categoryName": "Has Number",
+          "operands": 0,
+          "type": "has_number",
+          "verboseName": "has a number",
+        },
+        Object {
+          "operands": 2,
+          "type": "has_number_between",
+          "verboseName": "has a number between",
+        },
+        Object {
+          "operands": 1,
+          "type": "has_number_lt",
+          "verboseName": "has a number below",
+        },
+        Object {
+          "operands": 1,
+          "type": "has_number_lte",
+          "verboseName": "has a number at or below",
+        },
+        Object {
+          "operands": 1,
+          "type": "has_number_eq",
+          "verboseName": "has a number equal to",
+        },
+        Object {
+          "operands": 1,
+          "type": "has_number_gte",
+          "verboseName": "has a number at or above",
+        },
+        Object {
+          "operands": 1,
+          "type": "has_number_gt",
+          "verboseName": "has a number above",
+        },
+      ]
+    }
   />
   <OptionalTextInput
     helpText={

--- a/src/components/flow/routers/result/__snapshots__/ResultRouterForm.test.tsx.snap
+++ b/src/components/flow/routers/result/__snapshots__/ResultRouterForm.test.tsx.snap
@@ -210,7 +210,7 @@ exports[`ResultRouterForm should render 1`] = `
                         name="operator"
                         namekey="verboseName"
                         valuekey="type"
-                        values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1,\\"visibility\\":[\\"messaging\\",\\"messaging_background\\",\\"messaging_offline\\"]}]"
+                        values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1}]"
                       />
                     </div>
                   </div>
@@ -484,7 +484,7 @@ exports[`ResultRouterForm should show delimit options 1`] = `
                         name="operator"
                         namekey="verboseName"
                         valuekey="type"
-                        values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1,\\"visibility\\":[\\"messaging\\",\\"messaging_background\\",\\"messaging_offline\\"]}]"
+                        values="[{\\"type\\":\\"has_any_word\\",\\"verboseName\\":\\"has any of the words\\",\\"operands\\":1}]"
                       />
                     </div>
                   </div>

--- a/src/config/__snapshots__/operatorConfigs.test.ts.snap
+++ b/src/config/__snapshots__/operatorConfigs.test.ts.snap
@@ -6,41 +6,21 @@ Array [
     "operands": 1,
     "type": "has_any_word",
     "verboseName": "has any of the words",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   Object {
     "operands": 1,
     "type": "has_all_words",
     "verboseName": "has all of the words",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   Object {
     "operands": 1,
     "type": "has_phrase",
     "verboseName": "has the phrase",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   Object {
     "operands": 1,
     "type": "has_only_phrase",
     "verboseName": "has only the phrase",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   Object {
     "operands": 1,
@@ -52,11 +32,6 @@ Array [
     "operands": 0,
     "type": "has_text",
     "verboseName": "has some text",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   Object {
     "categoryName": "Has Number",
@@ -99,52 +74,27 @@ Array [
     "operands": 0,
     "type": "has_date",
     "verboseName": "has a date",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   Object {
     "operands": 1,
     "type": "has_date_lt",
     "verboseName": "has a date before",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   Object {
     "operands": 1,
     "type": "has_date_eq",
     "verboseName": "has a date equal to",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   Object {
     "operands": 1,
     "type": "has_date_gt",
     "verboseName": "has a date after",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   Object {
     "categoryName": "Has Time",
     "operands": 0,
     "type": "has_time",
     "verboseName": "has a time",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   Object {
     "operands": 1,
@@ -173,11 +123,6 @@ Array [
     "operands": 0,
     "type": "has_email",
     "verboseName": "has an email",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   Object {
     "categoryName": "Has State",
@@ -229,21 +174,11 @@ Object {
     "operands": 1,
     "type": "has_all_words",
     "verboseName": "has all of the words",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   "has_any_word": Object {
     "operands": 1,
     "type": "has_any_word",
     "verboseName": "has any of the words",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   "has_beginning": Object {
     "operands": 1,
@@ -263,41 +198,21 @@ Object {
     "operands": 0,
     "type": "has_date",
     "verboseName": "has a date",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   "has_date_eq": Object {
     "operands": 1,
     "type": "has_date_eq",
     "verboseName": "has a date equal to",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   "has_date_gt": Object {
     "operands": 1,
     "type": "has_date_gt",
     "verboseName": "has a date after",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   "has_date_lt": Object {
     "operands": 1,
     "type": "has_date_lt",
     "verboseName": "has a date before",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   "has_district": Object {
     "categoryName": "Has District",
@@ -310,11 +225,6 @@ Object {
     "operands": 0,
     "type": "has_email",
     "verboseName": "has an email",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   "has_error": Object {
     "categoryName": "Has Error",
@@ -383,11 +293,6 @@ Object {
     "operands": 1,
     "type": "has_only_phrase",
     "verboseName": "has only the phrase",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   "has_pattern": Object {
     "operands": 1,
@@ -404,11 +309,6 @@ Object {
     "operands": 1,
     "type": "has_phrase",
     "verboseName": "has the phrase",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   "has_state": Object {
     "categoryName": "Has State",
@@ -421,22 +321,12 @@ Object {
     "operands": 0,
     "type": "has_text",
     "verboseName": "has some text",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   "has_time": Object {
     "categoryName": "Has Time",
     "operands": 0,
     "type": "has_time",
     "verboseName": "has a time",
-    "visibility": Array [
-      "messaging",
-      "messaging_background",
-      "messaging_offline",
-    ],
   },
   "has_top_intent": Object {
     "operands": 2,

--- a/src/config/operatorConfigs.ts
+++ b/src/config/operatorConfigs.ts
@@ -27,26 +27,22 @@ export const operatorConfigList: Operator[] = [
   {
     type: Operators.has_any_word,
     verboseName: i18n.t('operators.has_any_word', 'has any of the words'),
-    operands: 1,
-    visibility: VISIBILITY_MESSAGING
+    operands: 1
   },
   {
     type: Operators.has_all_words,
     verboseName: i18n.t('operators.has_all_words', 'has all of the words'),
-    operands: 1,
-    visibility: VISIBILITY_MESSAGING
+    operands: 1
   },
   {
     type: Operators.has_phrase,
     verboseName: i18n.t('operators.has_phrase', 'has the phrase'),
-    operands: 1,
-    visibility: VISIBILITY_MESSAGING
+    operands: 1
   },
   {
     type: Operators.has_only_phrase,
     verboseName: i18n.t('operators.has_only_phrase', 'has only the phrase'),
-    operands: 1,
-    visibility: VISIBILITY_MESSAGING
+    operands: 1
   },
   {
     type: Operators.has_beginning,
@@ -57,8 +53,7 @@ export const operatorConfigList: Operator[] = [
     type: Operators.has_text,
     verboseName: i18n.t('operators.has_text', 'has some text'),
     operands: 0,
-    categoryName: 'Has Text',
-    visibility: VISIBILITY_MESSAGING
+    categoryName: 'Has Text'
   },
   {
     type: Operators.has_number,
@@ -100,33 +95,28 @@ export const operatorConfigList: Operator[] = [
     type: Operators.has_date,
     verboseName: i18n.t('operators.has_date', 'has a date'),
     operands: 0,
-    categoryName: i18n.t('operators.has_date_category', 'Has Date'),
-    visibility: VISIBILITY_MESSAGING
+    categoryName: i18n.t('operators.has_date_category', 'Has Date')
   },
   {
     type: Operators.has_date_lt,
     verboseName: i18n.t('operators.has_date_lt', 'has a date before'),
-    operands: 1,
-    visibility: VISIBILITY_MESSAGING
+    operands: 1
   },
   {
     type: Operators.has_date_eq,
     verboseName: i18n.t('operators.has_date_eq', 'has a date equal to'),
-    operands: 1,
-    visibility: VISIBILITY_MESSAGING
+    operands: 1
   },
   {
     type: Operators.has_date_gt,
     verboseName: i18n.t('operators.has_date_gt', 'has a date after'),
-    operands: 1,
-    visibility: VISIBILITY_MESSAGING
+    operands: 1
   },
   {
     type: Operators.has_time,
     verboseName: i18n.t('operators.has_time', 'has a time'),
     operands: 0,
-    categoryName: 'Has Time',
-    visibility: VISIBILITY_MESSAGING
+    categoryName: 'Has Time'
   },
   {
     type: Operators.has_group,
@@ -150,8 +140,7 @@ export const operatorConfigList: Operator[] = [
     type: Operators.has_email,
     verboseName: i18n.t('operators.has_email', 'has an email'),
     operands: 0,
-    categoryName: i18n.t('operators.has_email_category', 'Has Email'),
-    visibility: VISIBILITY_MESSAGING
+    categoryName: i18n.t('operators.has_email_category', 'Has Email')
   },
   {
     type: Operators.has_state,

--- a/src/config/operatorConfigs.ts
+++ b/src/config/operatorConfigs.ts
@@ -2,7 +2,6 @@ import {
   Operator,
   OperatorMap,
   Operators,
-  VISIBILITY_MESSAGING,
   VISIBILITY_ONLINE,
   VISIBILITY_HIDDEN
 } from 'config/interfaces';


### PR DESCRIPTION
* Allow text rules in ivr flows in all splits but the digit router
* Fixes issue making sure the default rule is not one that has been filtered out.

Also snuck in.. 
fixes: https://github.com/rapidpro/rapidpro/issues/1432