### PR TITLE
Simulator should use wait events rather than the wait object

### DIFF
--- a/src/components/simulator/LogEvent.tsx
+++ b/src/components/simulator/LogEvent.tsx
@@ -3,7 +3,7 @@ import { MediaPlayer } from 'components/mediaplayer/MediaPlayer';
 import Modal from 'components/modal/Modal';
 import styles from 'components/simulator/LogEvent.module.scss';
 import { Types } from 'config/interfaces';
-import { Flow, Group, Label, Topic } from 'flowTypes';
+import { Flow, Group, Label, Topic, Hint } from 'flowTypes';
 import * as React from 'react';
 import { createUUID, getURNPath } from 'utils';
 import i18n from 'config/i18n';
@@ -72,6 +72,8 @@ export interface EventProps {
   classifier?: { uuid: string; name: string };
   ticketer?: { uuid: string; name: string };
   ticket?: { topic: Topic; body: string };
+  hint?: Hint;
+  timeout_seconds?: number;
 }
 
 interface FlowEvent {

--- a/src/components/simulator/Simulator.tsx
+++ b/src/components/simulator/Simulator.tsx
@@ -6,7 +6,7 @@ import ContextExplorer from './ContextExplorer';
 import styles from 'components/simulator/Simulator.module.scss';
 import { ConfigProviderContext, fakePropType } from 'config/ConfigProvider';
 import { getURL } from 'external';
-import { FlowDefinition, Group, Wait } from 'flowTypes';
+import { FlowDefinition, Group } from 'flowTypes';
 import update from 'immutability-helper';
 import { ReactNode } from 'react';
 import React from 'react';
@@ -131,7 +131,6 @@ interface Run {
   flow_uuid: string;
   status: string;
   events?: EventProps[];
-  wait?: Wait;
 }
 
 interface RunContext {
@@ -145,8 +144,7 @@ interface Session {
   runs: Run[];
   contact: Contact;
   input?: any;
-  wait?: Wait;
-  status?: string;
+  status: string;
 }
 
 /**
@@ -391,16 +389,20 @@ export class Simulator extends React.Component<SimulatorProps, SimulatorState> {
       const newlyRecentMessages = {};
 
       this.updateEvents(runContext.events, runContext.session, newlyRecentMessages, () => {
-        let active = false;
-        for (const run of runContext.session.runs) {
-          if (run.status === 'waiting') {
-            active = true;
-            break;
+        let waiting = runContext.session.status === 'waiting';
+        let waitEvent: EventProps = null;
+
+        if (waiting) {
+          // if session is waiting then we should have a wait event
+          for (const evt of runContext.events) {
+            if (evt.type.endsWith('_wait')) {
+              waitEvent = evt;
+            }
           }
         }
 
         let newEvents = this.state.events;
-        if (!active && wasJustActive) {
+        if (!waiting && wasJustActive) {
           newEvents = update(this.state.events, {
             $push: [
               {
@@ -412,14 +414,11 @@ export class Simulator extends React.Component<SimulatorProps, SimulatorState> {
           }) as EventProps[];
         }
 
-        const waitingForHint =
-          runContext.session &&
-          runContext.session.wait &&
-          runContext.session.wait.hint !== undefined;
+        const waitingForHint = waitEvent && waitEvent.hint !== undefined;
 
         let drawerType = null;
         if (waitingForHint) {
-          switch (runContext.session.wait.hint.type) {
+          switch (waitEvent.hint.type) {
             case 'audio':
               drawerType = DrawerType.audio;
               break;
@@ -434,12 +433,12 @@ export class Simulator extends React.Component<SimulatorProps, SimulatorState> {
               break;
             case 'digits':
               drawerType = DrawerType.digit;
-              if (runContext.session.wait.hint.count !== 1) {
+              if (waitEvent.hint.count !== 1) {
                 drawerType = DrawerType.digits;
               }
               break;
             default:
-              console.log('Unknown hint', runContext.session.wait.hint.type);
+              console.log('Unknown hint', waitEvent.hint.type);
           }
         }
 
@@ -453,7 +452,7 @@ export class Simulator extends React.Component<SimulatorProps, SimulatorState> {
 
         this.setState(
           {
-            active,
+            active: waiting,
             context: runContext.context,
             sprinting: false,
             session: runContext.session,


### PR DESCRIPTION
Trying to get rid of wait objects on sessions because it's just duplication of what is in the wait event. Mailroom doesn't use them.