### PR TITLE
Fire event when node selection changes

### DIFF
--- a/src/components/canvas/Canvas.tsx
+++ b/src/components/canvas/Canvas.tsx
@@ -286,13 +286,23 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
       });
     }
 
+    let selected = this.state.selected;
     if (!this.justSelected) {
       this.props.mergeEditorState({
         dragActive: false
       });
 
       this.setState({ selected: {} });
+      selected = {};
     }
+
+    // trigger a bubbling event of our selection
+    this.ele.dispatchEvent(
+      new CustomEvent('temba-node-selection-changed', {
+        detail: { nodes: selected },
+        bubbles: true
+      })
+    );
 
     if (this.state.dragSelection && this.state.dragSelection.startX) {
       this.setState({


### PR DESCRIPTION
The containing page can register for the `temba-node-selection-changed` event:
```javascript
document.addEventListener("temba-node-selection-changed", function(event){
  console.log(event.detail);
});
```

Which would yield something like this:
```javascript
{
  "nodes": {
      "1bb35e73-f635-42b1-b9c9-0b7798c936e9": {left: 340, top: 40, right: 1177, bottom: 148},
      "2bc3f025-8d5e-47b3-9ac8-0ef3aef66d42": {left: 380, top: 220, right: 588, bottom: 367},
      "5bbb1209-b12e-4353-9823-1fb5715ed288": {left: 40, top: 0, right: 248, bottom: 294},
  }
}
```

Closes #1017