### PR TITLE
excluding all date, time, and numeric rules from translations

### DIFF
--- a/src/components/flow/routers/localization/RouterLocalizationForm.tsx
+++ b/src/components/flow/routers/localization/RouterLocalizationForm.tsx
@@ -120,7 +120,15 @@ export default class RouterLocalizationForm extends React.Component<
 
       const { verboseName } = getOperatorConfig(originalCase.type);
 
-      if (originalCase.arguments && originalCase.type !== Operators.has_number_between) {
+      const numericOperators = Object.values(Operators).filter(operator => {
+        return (
+          operator.startsWith(Operators.has_date) ||
+          operator.startsWith(Operators.has_time) ||
+          operator.startsWith(Operators.has_number)
+        );
+      });
+
+      if (originalCase.arguments && !numericOperators.includes(originalCase.type)) {
         const cat_uuid = originalCase.category_uuid;
         const originalCategory = getOriginalCategory(this.props.nodeSettings, cat_uuid);
         const originalArgument = originalCategory.name;


### PR DESCRIPTION
8 total rules, 6 numeric rules, 2 non-numeric -> only the 2 non-numeric rules display in the rule translations tab list

AFTER 1/3
<img width="673" alt="Screen Shot 2022-11-08 at 2 21 09 PM" src="https://user-images.githubusercontent.com/854012/200500655-ff992303-11a3-4bd6-bfc2-f5443a529b04.png">

AFTER 2/3
<img width="679" alt="Screen Shot 2022-11-08 at 2 21 20 PM" src="https://user-images.githubusercontent.com/854012/200500653-705d1619-d1af-4cce-b3e0-3bf8b77104dd.png">

AFTER 3/3
<img width="674" alt="Screen Shot 2022-11-08 at 2 21 35 PM" src="https://user-images.githubusercontent.com/854012/200500687-b7f6ab88-3600-4195-b5e6-a3150766ed1e.png">
