### PR TITLE
Fix: Creating a new node after a horizontal scroll causes the new node to move to some distance

### DIFF
--- a/src/components/flow/node/Node.tsx
+++ b/src/components/flow/node/Node.tsx
@@ -129,7 +129,7 @@ export class NodeComp extends React.PureComponent<NodeProps> {
 
         // move our ghost node into position
         const width = this.ele.getBoundingClientRect().width;
-        const left = e.pageX - width / 2 - 15 - canvasBounds.left;
+        const left = e.screenX - width / 2 - 15 - canvasBounds.left;
         const top = e.pageY - canvasBounds.top - window.scrollY;
         const style = this.ele.style;
         style.left = left + 'px';


### PR DESCRIPTION
## Summary

While trying to fix the https://github.com/nyaruka/rapidpro/issues/4303 this issue https://github.com/nyaruka/floweditor/issues/1054 comes up in editor. 

The issue is replicable when we try to just load the editor without Rapidpro. Just scroll horizontally to some distance and try to add a new node. Have tried this on https://floweditor.nyaruka.com and this issue is present there.

I have added a fix for this by changing the pageX attribute to screenX which seems to fix the issue in this case and helps in fixing the scroll issue when we open revision history. Please let me know if this change looks fine.