### PR TITLE
Auto translation updates

### DIFF
--- a/src/flowTypes.ts
+++ b/src/flowTypes.ts
@@ -489,6 +489,7 @@ export interface UIMetaData {
   nodes: { [key: string]: UINode };
   languages: { [iso: string]: string }[];
   translation_filters?: { categories: boolean };
+  auto_translations?: { [language: string]: { [uuid: string]: string[] } };
 }
 
 export interface FlowPosition {

--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -232,7 +232,8 @@ export const getCurrentDefinition = (
       nodes: uiNodes,
       stickies: definition._ui.stickies,
       languages: definition._ui.languages,
-      translation_filters: definition._ui.translation_filters
+      translation_filters: definition._ui.translation_filters,
+      auto_translations: definition._ui.auto_translations
     } as UIMetaData;
   }
 

--- a/src/store/mutators.test.ts
+++ b/src/store/mutators.test.ts
@@ -235,7 +235,12 @@ describe('mutators', () => {
     expect(updated).toMatchSnapshot();
 
     // now clear it
-    updated = updateLocalization(updated, 'spa', [{ uuid: 'node0_action0', translations: null }]);
+    updated = updateLocalization(
+      updated,
+      'spa',
+      [{ uuid: 'node0_action0', translations: null }],
+      false
+    );
     expect(updated.localization.spa).toEqual({});
     expect(updated).toMatchSnapshot();
   });

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -118,7 +118,7 @@ export type OnConnectionDrag = (event: ConnectionEvent, flowType: FlowTypes) => 
 
 export type OnUpdateLocalizations = (
   language: string,
-  merge: boolean,
+  autoTranslated: boolean,
   changes: LocalizationUpdates
 ) => Thunk<FlowDefinition>;
 
@@ -508,14 +508,14 @@ export const onRemoveLocalizations = (uuid: string, keys?: string[]) => (
 
 export const onUpdateLocalizations = (
   language: string,
-  merge: boolean,
+  autoTranslated: boolean,
   changes: LocalizationUpdates
 ) => (dispatch: DispatchWithState, getState: GetState): FlowDefinition => {
   const {
     flowContext: { definition }
   } = getState();
 
-  const updated = mutators.updateLocalization(definition, language, changes, merge);
+  const updated = mutators.updateLocalization(definition, language, changes, autoTranslated);
   dispatch(updateDefinition(updated));
 
   markDirty();


### PR DESCRIPTION
* Skip single character and numeric translation requests
* Handle ai.reasoning errors
* Keep record of which attributes have been auto translated for each node